### PR TITLE
Enhance web UI with pixel-retro style and simpler UX flow

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -22,4 +22,12 @@ export default defineConfig([
       globals: globals.browser,
     },
   },
+  {
+    files: ['src/game/GameCanvas.tsx'],
+    rules: {
+      // Phaser scene lifecycle functions rely on framework-bound `this`.
+      // This syntax is valid for Phaser and not related to React hooks behavior.
+      'react-hooks/unsupported-syntax': 'off',
+    },
+  },
 ])

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -21,42 +21,44 @@ export default function Header() {
   }
 
   return (
-    <header className="bg-white shadow-sm">
-      <div className="max-w-5xl mx-auto px-4 py-5 flex items-center justify-between">
-        <Link to="/" className="text-2xl font-bold text-gray-900">
-          Generative Agents — Reverie
+    <header className="retro-header">
+      <div className="retro-header-inner flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <Link to="/" className="retro-brand">
+          Reverie Pixel Town
         </Link>
-        <nav className="flex gap-6 items-center">
+        <nav className="flex flex-wrap gap-2 items-center">
           {user ? (
             <>
-              <Link to="/dashboard" className="text-blue-600 hover:text-blue-800 font-medium">
+              <Link to="/dashboard" className="retro-navlink">
                 Dashboard
               </Link>
-              <Link to="/explore" className="text-blue-600 hover:text-blue-800 font-medium">
+              <Link to="/explore" className="retro-navlink">
                 Explore
               </Link>
-              <Link to="/invites" className="relative text-blue-600 hover:text-blue-800 font-medium">
+              <Link to="/invites" className="relative retro-navlink">
                 Invites
                 {pendingInvites > 0 && (
-                  <span className="absolute -top-2 -right-3 bg-red-500 text-white text-xs rounded-full w-4 h-4 flex items-center justify-center">
+                  <span className="absolute -top-2 -right-3 retro-badge bg-red-500 text-white">
                     {pendingInvites}
                   </span>
                 )}
               </Link>
-              <span className="text-gray-700 font-medium">{user.username}</span>
+              <span className="text-xs md:text-sm font-bold uppercase tracking-wide text-gray-700">
+                {user.username}
+              </span>
               <button
                 onClick={() => void handleLogout()}
-                className="text-red-600 hover:text-red-800 font-medium"
+                className="retro-button retro-button-danger"
               >
                 Logout
               </button>
             </>
           ) : (
             <>
-              <Link to="/login" className="text-blue-600 hover:text-blue-800 font-medium">
+              <Link to="/login" className="retro-navlink">
                 Login
               </Link>
-              <Link to="/register" className="text-blue-600 hover:text-blue-800 font-medium">
+              <Link to="/register" className="retro-navlink">
                 Register
               </Link>
             </>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,359 @@
 @import 'tailwindcss';
+
+:root {
+  --retro-sky: #77bef0;
+  --retro-sun: #ffcb61;
+  --retro-orange: #ff894f;
+  --retro-rose: #ea5b6f;
+  --retro-paper: #fffdf3;
+  --retro-ink: #2f2a3a;
+  --retro-shadow: #9d4f5c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  color: var(--retro-ink);
+  font-family: 'Press Start 2P', 'Trebuchet MS', 'Verdana', sans-serif;
+  background:
+    linear-gradient(90deg, rgb(119 190 240 / 15%) 1px, transparent 1px) 0 0 / 20px 20px,
+    linear-gradient(rgb(255 203 97 / 20%) 1px, transparent 1px) 0 0 / 20px 20px,
+    var(--retro-paper);
+}
+
+a {
+  color: inherit;
+}
+
+.retro-page {
+  min-height: 100vh;
+  background: transparent;
+}
+
+.retro-main {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: 2rem 1rem 2.5rem;
+}
+
+.retro-header {
+  background: var(--retro-sky);
+  border-bottom: 4px solid var(--retro-orange);
+  box-shadow: 0 6px 0 var(--retro-shadow);
+}
+
+.retro-header-inner {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.retro-brand {
+  color: var(--retro-ink);
+  font-size: 1.15rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.retro-title {
+  color: var(--retro-ink);
+  font-size: clamp(1.3rem, 3vw, 2rem);
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.retro-subtitle {
+  color: color-mix(in srgb, var(--retro-ink) 82%, white);
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.retro-panel {
+  background: var(--retro-paper);
+  border: 3px solid var(--retro-orange);
+  border-radius: 0;
+  box-shadow: 6px 6px 0 var(--retro-shadow);
+}
+
+.retro-navlink {
+  border: 2px solid var(--retro-ink);
+  background: var(--retro-sun);
+  color: var(--retro-ink);
+  text-transform: uppercase;
+  font-weight: 700;
+  font-size: 0.74rem;
+  letter-spacing: 0.03em;
+  padding: 0.35rem 0.55rem;
+  text-decoration: none;
+}
+
+.retro-navlink:hover {
+  background: var(--retro-orange);
+}
+
+.retro-link {
+  color: var(--retro-rose);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  font-weight: 700;
+}
+
+.retro-input,
+.retro-select,
+.retro-textarea {
+  width: 100%;
+  border: 2px solid var(--retro-ink);
+  border-radius: 0;
+  background: #fff;
+  color: var(--retro-ink);
+  padding: 0.65rem 0.8rem;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.retro-select {
+  width: auto;
+}
+
+.retro-input:focus,
+.retro-select:focus,
+.retro-textarea:focus {
+  outline: 3px solid var(--retro-sky);
+  outline-offset: 1px;
+}
+
+.retro-button {
+  border: 2px solid var(--retro-ink);
+  border-radius: 0;
+  padding: 0.55rem 0.95rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.retro-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.retro-button-primary {
+  background: var(--retro-sky);
+  color: var(--retro-ink);
+}
+
+.retro-button-primary:hover:not(:disabled) {
+  background: #5ea8dc;
+}
+
+.retro-button-warm {
+  background: var(--retro-sun);
+  color: var(--retro-ink);
+}
+
+.retro-button-warm:hover:not(:disabled) {
+  background: var(--retro-orange);
+}
+
+.retro-button-danger {
+  background: var(--retro-rose);
+  color: #fff;
+}
+
+.retro-button-danger:hover:not(:disabled) {
+  background: #cf4c61;
+}
+
+.retro-button-ghost {
+  background: #fff;
+  color: var(--retro-ink);
+}
+
+.retro-button-ghost:hover:not(:disabled) {
+  background: #f6f1dd;
+}
+
+.retro-badge {
+  border: 2px solid var(--retro-ink);
+  border-radius: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.2rem;
+  min-height: 1.2rem;
+  font-weight: 800;
+  font-size: 0.64rem;
+  line-height: 1;
+}
+
+.retro-empty-state {
+  text-align: center;
+  color: color-mix(in srgb, var(--retro-ink) 78%, white);
+  border: 2px dashed var(--retro-sky);
+  background: #fff;
+  padding: 1.2rem;
+}
+
+.retro-steps {
+  border: 3px solid var(--retro-sky);
+  background: color-mix(in srgb, var(--retro-sky) 20%, white);
+  padding: 1rem;
+}
+
+.retro-step-item {
+  display: flex;
+  gap: 0.7rem;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+}
+
+.retro-step-item:last-child {
+  margin-bottom: 0;
+}
+
+.retro-step-count {
+  flex: none;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--retro-ink);
+  background: var(--retro-sun);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+/* Palette mapping for existing Tailwind color utility usage */
+[class~='bg-gray-50'] {
+  background-color: var(--retro-paper) !important;
+}
+
+[class~='bg-white'] {
+  background-color: #fffdf7 !important;
+}
+
+[class~='bg-gray-900'] {
+  background-color: #2f2a3a !important;
+}
+
+[class~='bg-gray-800'] {
+  background-color: #42395b !important;
+}
+
+[class~='bg-gray-700'] {
+  background-color: #5a4f79 !important;
+}
+
+[class~='bg-gray-600'] {
+  background-color: #74679a !important;
+}
+
+[class~='bg-blue-50'] {
+  background-color: color-mix(in srgb, var(--retro-sky) 20%, white) !important;
+}
+
+[class~='bg-blue-600'],
+[class~='bg-blue-500'] {
+  background-color: var(--retro-sky) !important;
+}
+
+[class~='hover:bg-blue-700']:hover,
+[class~='hover:bg-blue-600']:hover,
+[class~='hover:bg-blue-500']:hover {
+  background-color: #5ea8dc !important;
+}
+
+[class~='bg-green-600'],
+[class~='bg-green-700'] {
+  background-color: var(--retro-sun) !important;
+  color: var(--retro-ink) !important;
+}
+
+[class~='bg-yellow-600'],
+[class~='bg-yellow-700'] {
+  background-color: var(--retro-orange) !important;
+}
+
+[class~='bg-red-600'],
+[class~='bg-red-500'],
+[class~='bg-red-700'] {
+  background-color: var(--retro-rose) !important;
+}
+
+[class~='text-gray-900'],
+[class~='text-gray-800'],
+[class~='text-gray-700'] {
+  color: var(--retro-ink) !important;
+}
+
+[class~='text-gray-600'],
+[class~='text-gray-500'],
+[class~='text-gray-400'] {
+  color: color-mix(in srgb, var(--retro-ink) 74%, white) !important;
+}
+
+[class~='text-blue-600'],
+[class~='text-blue-400'] {
+  color: var(--retro-rose) !important;
+}
+
+[class~='hover:text-blue-800']:hover,
+[class~='hover:text-blue-600']:hover,
+[class~='hover:text-blue-400']:hover {
+  color: #b94053 !important;
+}
+
+[class~='text-green-700'],
+[class~='text-green-600'] {
+  color: #956800 !important;
+}
+
+[class~='text-yellow-700'] {
+  color: #a14d1f !important;
+}
+
+[class~='text-red-600'],
+[class~='text-red-500'],
+[class~='text-red-400'] {
+  color: var(--retro-rose) !important;
+}
+
+[class~='border-gray-100'],
+[class~='border-gray-200'],
+[class~='border-gray-300'],
+[class~='border-gray-600'],
+[class~='border-gray-700'] {
+  border-color: color-mix(in srgb, var(--retro-ink) 45%, white) !important;
+}
+
+[class~='border-blue-500'] {
+  border-color: var(--retro-sky) !important;
+}
+
+[class~='border-red-200'] {
+  border-color: var(--retro-rose) !important;
+}
+
+[class~='rounded-xl'],
+[class~='rounded-lg'],
+[class~='rounded'] {
+  border-radius: 0 !important;
+}
+
+[class~='shadow'],
+[class~='shadow-sm'],
+[class~='shadow-md'],
+[class~='shadow-xl'] {
+  box-shadow: 5px 5px 0 rgb(159 77 95 / 65%) !important;
+}
+
+[class~='accent-blue-500'] {
+  accent-color: var(--retro-sky);
+}

--- a/frontend/src/pages/CharactersPage.tsx
+++ b/frontend/src/pages/CharactersPage.tsx
@@ -35,21 +35,21 @@ export default function CharactersPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="retro-page">
       <Header />
-      <main className="max-w-5xl mx-auto px-4 py-10">
+      <main className="retro-main">
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-3xl font-bold text-gray-900">My Characters</h2>
+          <h2 className="retro-title">My Characters</h2>
           <Link
             to="/characters/new"
-            className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+            className="retro-button retro-button-primary"
           >
             Create character
           </Link>
         </div>
 
         {deleteError && (
-          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-600 text-sm">
+          <div className="retro-panel mb-4 p-3 text-sm text-red-600">
             {deleteError}
           </div>
         )}
@@ -57,16 +57,16 @@ export default function CharactersPage() {
         {loading ? (
           <p className="text-gray-500">Loading…</p>
         ) : characters.length === 0 ? (
-          <div className="bg-white rounded-xl border border-gray-100 shadow p-8 text-center text-gray-500">
+          <div className="retro-panel retro-empty-state p-8">
             No characters yet.{' '}
-            <Link to="/characters/new" className="text-blue-600 hover:underline">
+            <Link to="/characters/new" className="retro-link">
               Create your first character
             </Link>
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {characters.map((char) => (
-              <div key={char.id} className="bg-white rounded-xl border border-gray-100 shadow p-5">
+              <div key={char.id} className="retro-panel p-5">
                 <div className="flex items-start justify-between mb-2">
                   <div>
                     <h3 className="font-semibold text-gray-900">{char.name}</h3>
@@ -90,7 +90,7 @@ export default function CharactersPage() {
                 <div className="flex gap-2 mt-3">
                   <Link
                     to={`/characters/${char.id}/edit`}
-                    className="text-sm text-blue-600 hover:underline"
+                    className="text-sm retro-link"
                   >
                     Edit
                   </Link>
@@ -104,7 +104,7 @@ export default function CharactersPage() {
                   ) : (
                     <button
                       onClick={() => void handleDelete(char)}
-                      className="text-sm text-red-600 hover:underline"
+                      className="text-sm text-red-600 underline"
                     >
                       Delete
                     </button>

--- a/frontend/src/pages/CreateCharacterPage.tsx
+++ b/frontend/src/pages/CreateCharacterPage.tsx
@@ -44,14 +44,14 @@ export default function CreateCharacterPage() {
   const fieldError = (field: string) => errors[field]?.[0] ?? null
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="retro-page">
       <Header />
-      <main className="max-w-2xl mx-auto px-4 py-10">
-        <h2 className="text-3xl font-bold text-gray-900 mb-8">Create Character</h2>
-        <div className="bg-white rounded-xl border border-gray-100 shadow p-8">
+      <main className="retro-main max-w-2xl">
+        <h2 className="retro-title mb-6">Create character</h2>
+        <div className="retro-panel p-6">
           <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-xs font-bold uppercase mb-1">
                 Name <span className="text-red-500">*</span>
               </label>
               <input
@@ -59,43 +59,43 @@ export default function CreateCharacterPage() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="e.g. Isabella Rodriguez"
-                className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="retro-input"
               />
               {fieldError('name') && <p className="mt-1 text-sm text-red-600">{fieldError('name')}</p>}
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Age</label>
+              <label className="block text-xs font-bold uppercase mb-1">Age</label>
               <input
                 type="number"
                 value={age}
                 onChange={(e) => setAge(e.target.value)}
                 placeholder="e.g. 34"
                 min={0}
-                className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="retro-input"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Traits</label>
+              <label className="block text-xs font-bold uppercase mb-1">Traits</label>
               <textarea
                 value={traits}
                 onChange={(e) => setTraits(e.target.value)}
                 placeholder="e.g. friendly, artistic, curious about people"
                 rows={2}
-                className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="retro-textarea"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Backstory</label>
+              <label className="block text-xs font-bold uppercase mb-1">Backstory</label>
               <textarea
                 value={backstory}
                 onChange={(e) => setBackstory(e.target.value)}
                 placeholder="e.g. Grew up in a small town and moved to the city to pursue a career in art"
                 rows={3}
-                className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="retro-textarea"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-xs font-bold uppercase mb-1">
                 Currently (what they&apos;re doing)
               </label>
               <textarea
@@ -103,27 +103,27 @@ export default function CreateCharacterPage() {
                 onChange={(e) => setCurrently(e.target.value)}
                 placeholder="e.g. Running the Oak Hill Cafe and taking painting classes on Saturdays"
                 rows={2}
-                className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="retro-textarea"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Lifestyle</label>
+              <label className="block text-xs font-bold uppercase mb-1">Lifestyle</label>
               <textarea
                 value={lifestyle}
                 onChange={(e) => setLifestyle(e.target.value)}
                 placeholder="e.g. Loves morning runs, cooking, and weekly book club meetings"
                 rows={2}
-                className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="retro-textarea"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Daily Plan</label>
+              <label className="block text-xs font-bold uppercase mb-1">Daily plan</label>
               <textarea
                 value={dailyPlan}
                 onChange={(e) => setDailyPlan(e.target.value)}
                 placeholder="e.g. Wake up at 7am, run for 30 minutes, open the café at 9am..."
                 rows={3}
-                className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="retro-textarea"
               />
             </div>
 
@@ -135,14 +135,14 @@ export default function CreateCharacterPage() {
               <button
                 type="submit"
                 disabled={loading}
-                className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white font-medium px-6 py-2 rounded-lg transition-colors"
+                className="retro-button retro-button-primary"
               >
                 {loading ? 'Creating…' : 'Create Character'}
               </button>
               <button
                 type="button"
                 onClick={() => navigate('/characters')}
-                className="text-gray-600 hover:text-gray-900 font-medium px-4 py-2"
+                className="retro-button retro-button-ghost"
               >
                 Cancel
               </button>

--- a/frontend/src/pages/CreateSimulationPage.tsx
+++ b/frontend/src/pages/CreateSimulationPage.tsx
@@ -47,14 +47,17 @@ export default function CreateSimulationPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="retro-page">
       <Header />
-      <main className="max-w-4xl mx-auto px-4 py-10">
-        <h2 className="text-3xl font-bold text-gray-900 mb-8">New Simulation</h2>
+      <main className="retro-main max-w-4xl">
+        <h2 className="retro-title mb-3">Create simulation</h2>
+        <p className="retro-subtitle mb-6">
+          Choose a name, pick visibility, then select a map tile set to launch your pixel town.
+        </p>
         <form onSubmit={(e) => void handleSubmit(e)}>
-          <div className="bg-white rounded-xl border border-gray-100 shadow p-8 mb-6">
+          <div className="retro-panel p-6 md:p-8 mb-6">
             <div className="mb-6">
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-xs font-bold uppercase mb-1">
                 Simulation Name <span className="text-red-500">*</span>
               </label>
               <input
@@ -62,15 +65,15 @@ export default function CreateSimulationPage() {
                 value={simName}
                 onChange={(e) => setSimName(e.target.value)}
                 placeholder="e.g. my_ville_experiment"
-                className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="retro-input"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Visibility</label>
+              <label className="block text-xs font-bold uppercase mb-1">Visibility</label>
               <select
                 value={visibility}
                 onChange={(e) => setVisibility(e.target.value as 'private' | 'public' | 'shared')}
-                className="rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="retro-select"
               >
                 <option value="private">Private</option>
                 <option value="public">Public</option>
@@ -79,8 +82,8 @@ export default function CreateSimulationPage() {
             </div>
           </div>
 
-          <div className="bg-white rounded-xl border border-gray-100 shadow p-8 mb-6">
-            <h3 className="text-lg font-semibold text-gray-800 mb-4">Choose a Map</h3>
+          <div className="retro-panel p-6 md:p-8 mb-6">
+            <h3 className="retro-title text-lg mb-4">Choose a map</h3>
             {mapsLoading ? (
               <p className="text-gray-500">Loading maps…</p>
             ) : (
@@ -90,14 +93,14 @@ export default function CreateSimulationPage() {
                     key={map.id}
                     type="button"
                     onClick={() => setSelectedMapId(map.id)}
-                    className={`text-left p-4 rounded-xl border-2 transition-colors ${
+                    className={`text-left p-4 border-2 transition-colors ${
                       selectedMapId === map.id
-                        ? 'border-blue-500 bg-blue-50'
-                        : 'border-gray-200 bg-white hover:border-gray-300'
+                        ? 'border-blue-500 bg-blue-50 retro-panel'
+                        : 'border-gray-200 bg-white hover:border-blue-500'
                     }`}
                   >
-                    <h4 className="font-semibold text-gray-900">{map.name}</h4>
-                    <p className="text-sm text-gray-600 mt-1">{map.description}</p>
+                    <h4 className="font-bold uppercase text-sm text-gray-900">{map.name}</h4>
+                    <p className="text-xs text-gray-600 mt-1">{map.description}</p>
                     <p className="text-xs text-gray-400 mt-2">Max agents: {map.max_agents}</p>
                   </button>
                 ))}
@@ -106,7 +109,7 @@ export default function CreateSimulationPage() {
           </div>
 
           {error && (
-            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-600 text-sm">
+            <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-600 text-sm retro-panel">
               {error}
             </div>
           )}
@@ -115,14 +118,14 @@ export default function CreateSimulationPage() {
             <button
               type="submit"
               disabled={loading || mapsLoading}
-              className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white font-medium px-6 py-2 rounded-lg transition-colors"
+              className="retro-button retro-button-primary"
             >
               {loading ? 'Creating…' : 'Create Simulation'}
             </button>
             <button
               type="button"
               onClick={() => navigate('/dashboard')}
-              className="text-gray-600 hover:text-gray-900 font-medium px-4 py-2"
+              className="retro-button retro-button-ghost"
             >
               Cancel
             </button>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,7 +6,7 @@ import { fetchCharacters, type Character } from '../api/characters'
 
 function statusBadge(status?: string) {
   const colors: Record<string, string> = {
-    pending: 'bg-gray-100 text-gray-700',
+    pending: 'bg-blue-50 text-gray-700',
     running: 'bg-green-100 text-green-700',
     paused: 'bg-yellow-100 text-yellow-700',
     completed: 'bg-blue-100 text-blue-700',
@@ -14,7 +14,7 @@ function statusBadge(status?: string) {
   }
   const label = status ?? 'pending'
   return (
-    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${colors[label] ?? colors.pending}`}>
+    <span className={`retro-badge px-2 py-0.5 text-xs ${colors[label] ?? colors.pending}`}>
       {label}
     </span>
   )
@@ -44,18 +44,23 @@ export default function DashboardPage() {
   }, [])
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="retro-page">
       <Header />
-      <main className="max-w-5xl mx-auto px-4 py-10">
-        <h2 className="text-3xl font-bold text-gray-900 mb-8">Dashboard</h2>
+      <main className="retro-main">
+        <section className="retro-panel p-6 md:p-8 mb-6">
+          <h2 className="retro-title mb-2">Dashboard</h2>
+          <p className="retro-subtitle">
+            Simple flow: create a simulation, add characters, then observe behavior.
+          </p>
+        </section>
 
         {/* Simulations */}
-        <section className="mb-10">
+        <section className="retro-panel p-5 mb-6">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-xl font-semibold text-gray-800">My Simulations</h3>
+            <h3 className="retro-title text-lg">My simulations</h3>
             <Link
               to="/simulations/new"
-              className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+              className="retro-button retro-button-primary"
             >
               Create simulation
             </Link>
@@ -63,15 +68,15 @@ export default function DashboardPage() {
           {loading ? (
             <p className="text-gray-500">Loading…</p>
           ) : simulations.length === 0 ? (
-            <div className="bg-white rounded-xl border border-gray-100 shadow p-8 text-center text-gray-500">
+            <div className="retro-empty-state">
               No simulations yet. Create your first simulation!
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {simulations.map((sim) => (
-                <div key={sim.id} className="bg-white rounded-xl border border-gray-100 shadow p-5">
+                <div key={sim.id} className="retro-panel p-5">
                   <div className="flex items-center justify-between mb-2">
-                    <h4 className="font-semibold text-gray-900">{sim.name}</h4>
+                    <h4 className="font-semibold text-gray-900 uppercase tracking-wide">{sim.name}</h4>
                     {statusBadge(sim.status)}
                   </div>
                   <p className="text-sm text-gray-500 mb-1">Map: {sim.map_id ?? sim.maze_name ?? '—'}</p>
@@ -81,13 +86,13 @@ export default function DashboardPage() {
                   <div className="flex gap-2">
                     <Link
                       to={`/simulate/${encodeURIComponent(sim.id)}`}
-                      className="text-sm text-blue-600 hover:underline font-medium"
+                      className="retro-link text-sm"
                     >
                       Observe
                     </Link>
                     <Link
                       to={`/simulate/${encodeURIComponent(sim.id)}/settings`}
-                      className="text-sm text-gray-500 hover:underline"
+                      className="retro-link text-sm"
                     >
                       Settings
                     </Link>
@@ -99,12 +104,12 @@ export default function DashboardPage() {
         </section>
 
         {/* Characters */}
-        <section>
+        <section className="retro-panel p-5">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-xl font-semibold text-gray-800">My Characters</h3>
+            <h3 className="retro-title text-lg">My characters</h3>
             <Link
               to="/characters/new"
-              className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+              className="retro-button retro-button-primary"
             >
               Create character
             </Link>
@@ -112,14 +117,14 @@ export default function DashboardPage() {
           {loading ? (
             <p className="text-gray-500">Loading…</p>
           ) : characters.length === 0 ? (
-            <div className="bg-white rounded-xl border border-gray-100 shadow p-8 text-center text-gray-500">
+            <div className="retro-empty-state">
               No characters yet. Create your first character!
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               {characters.map((char) => (
-                <div key={char.id} className="bg-white rounded-xl border border-gray-100 shadow p-4">
-                  <h4 className="font-semibold text-gray-900">{char.name}</h4>
+                <div key={char.id} className="retro-panel p-4">
+                  <h4 className="font-semibold text-gray-900 uppercase tracking-wide">{char.name}</h4>
                   <p className="text-sm text-gray-500 mt-1">
                     Status:{' '}
                     <span

--- a/frontend/src/pages/DemoPage.tsx
+++ b/frontend/src/pages/DemoPage.tsx
@@ -32,35 +32,37 @@ function DemoPicker() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64 text-gray-400">
+      <div className="flex items-center justify-center h-64 text-gray-500">
         Loading demos…
       </div>
     )
   }
   if (error) {
     return (
-      <div className="flex items-center justify-center h-64 text-red-400">
+      <div className="flex items-center justify-center h-64 text-red-500">
         Error: {error}
       </div>
     )
   }
 
   return (
-    <div className="max-w-2xl mx-auto p-8">
-      <h2 className="text-xl font-semibold mb-4 text-white">Select a Demo</h2>
+    <div className="max-w-3xl mx-auto p-4 md:p-8">
+      <div className="retro-panel p-5">
+      <h2 className="retro-title text-lg mb-2">Select a Demo</h2>
+      <p className="retro-subtitle text-sm mb-4">Choose one recording to replay.</p>
       {demos.length === 0 ? (
-        <p className="text-gray-400">No demos found in compressed_storage/.</p>
+        <p className="retro-empty-state text-sm">No demos found in compressed_storage/.</p>
       ) : (
         <ul className="space-y-3">
           {demos.map((demo) => (
             <li key={demo.id}>
               <Link
                 to={`/demo/${encodeURIComponent(demo.id)}`}
-                className="block bg-gray-800 rounded-lg px-5 py-4 hover:bg-gray-700 transition-colors"
+                className="block retro-panel px-5 py-4 transition-colors hover:bg-blue-50"
               >
-                <div className="font-medium text-white">{demo.name}</div>
+                <div className="font-semibold text-gray-900">{demo.name}</div>
                 {demo.start_date && (
-                  <div className="text-sm text-gray-400 mt-1">Start: {demo.start_date}</div>
+                  <div className="text-sm text-gray-600 mt-1">Start: {demo.start_date}</div>
                 )}
                 <div className="text-sm text-gray-500 mt-1">
                   {demo.persona_names.length} agent{demo.persona_names.length !== 1 ? 's' : ''}
@@ -71,6 +73,7 @@ function DemoPicker() {
           ))}
         </ul>
       )}
+      </div>
     </div>
   )
 }
@@ -87,15 +90,15 @@ function DemoAgentCard({
   description: string
 }) {
   return (
-    <div className="bg-gray-800 rounded-lg p-3 mb-3">
+    <div className="retro-panel p-3 mb-3">
       <div className="flex items-center gap-2">
         <span className="text-lg" aria-hidden="true">
           {pronunciatio}
         </span>
-        <span className="font-semibold text-white text-sm">{name}</span>
+        <span className="font-semibold text-gray-900 text-sm">{name}</span>
       </div>
       {description && (
-        <div className="text-xs text-gray-400 mt-1 leading-snug">{description}</div>
+        <div className="text-xs text-gray-600 mt-1 leading-snug">{description}</div>
       )}
     </div>
   )
@@ -213,7 +216,7 @@ function DemoViewer({ demoId }: { demoId: string }) {
 
   if (error) {
     return (
-      <div className="flex items-center justify-center flex-1 text-red-400">
+      <div className="flex items-center justify-center flex-1 text-red-500">
         Error: {error}
       </div>
     )
@@ -226,32 +229,32 @@ function DemoViewer({ demoId }: { demoId: string }) {
         {/* Game canvas */}
         <div className="flex-1 overflow-hidden relative">
           <GameCanvas className="w-full h-full" agents={agents} />
-          <div className="absolute bottom-2 left-2 text-xs text-white bg-black/50 px-2 py-1 rounded pointer-events-none">
+          <div className="absolute bottom-2 left-2 text-xs text-gray-900 bg-blue-50 px-2 py-1 border-2 border-blue-500 pointer-events-none">
             Arrow keys to pan
           </div>
         </div>
 
         {/* Agent sidebar */}
-        <aside className="w-64 shrink-0 bg-gray-900 border-l border-gray-700 overflow-y-auto p-3">
+        <aside className="w-72 shrink-0 bg-white border-l border-gray-700 overflow-y-auto p-3">
           <div className="mb-3">
             {stepData && (
-              <div className="text-xs text-gray-400 mb-1">
-                <span className="font-medium text-gray-300">Step:</span> {stepData.step}
+              <div className="text-xs text-gray-500 mb-1">
+                <span className="font-medium text-gray-700">Step:</span> {stepData.step}
                 {totalSteps != null && (
                   <span className="text-gray-600"> / {totalSteps}</span>
                 )}
               </div>
             )}
             {meta?.start_date && (
-              <div className="text-xs text-gray-400 mb-1">
-                <span className="font-medium text-gray-300">Start:</span> {meta.start_date}
+              <div className="text-xs text-gray-500 mb-1">
+                <span className="font-medium text-gray-700">Start:</span> {meta.start_date}
               </div>
             )}
           </div>
 
           <hr className="border-gray-700 mb-3" />
 
-          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+          <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
             Agents ({agents.length})
           </h2>
 
@@ -271,12 +274,12 @@ function DemoViewer({ demoId }: { demoId: string }) {
       </div>
 
       {/* Playback controls bar */}
-      <div className="shrink-0 bg-gray-800 border-t border-gray-700 px-4 py-2 flex items-center gap-3">
+      <div className="shrink-0 bg-white border-t border-gray-700 px-4 py-2 flex items-center gap-3">
         {/* Step back */}
         <button
           onClick={stepBack}
           disabled={currentStep === 0}
-          className="px-2 py-1 text-sm bg-gray-700 hover:bg-gray-600 disabled:opacity-40 rounded"
+          className="retro-button retro-button-ghost text-sm px-2 py-1 disabled:opacity-40"
           title="Step back"
         >
           ◀
@@ -285,7 +288,7 @@ function DemoViewer({ demoId }: { demoId: string }) {
         {/* Play / Pause */}
         <button
           onClick={togglePlay}
-          className="px-3 py-1 text-sm bg-blue-600 hover:bg-blue-500 rounded font-medium"
+          className="retro-button retro-button-primary text-sm px-3 py-1"
           title={isPlaying ? 'Pause' : 'Play'}
         >
           {isPlaying ? '⏸ Pause' : '▶ Play'}
@@ -295,7 +298,7 @@ function DemoViewer({ demoId }: { demoId: string }) {
         <button
           onClick={stepForward}
           disabled={totalSteps != null && currentStep >= maxStep}
-          className="px-2 py-1 text-sm bg-gray-700 hover:bg-gray-600 disabled:opacity-40 rounded"
+          className="retro-button retro-button-ghost text-sm px-2 py-1 disabled:opacity-40"
           title="Step forward"
         >
           ▶
@@ -304,7 +307,7 @@ function DemoViewer({ demoId }: { demoId: string }) {
         {/* Speed toggle */}
         <button
           onClick={cycleSpeed}
-          className="px-2 py-1 text-sm bg-gray-700 hover:bg-gray-600 rounded"
+          className="retro-button retro-button-warm text-sm px-2 py-1"
           title="Playback speed"
         >
           {speed}×
@@ -312,7 +315,7 @@ function DemoViewer({ demoId }: { demoId: string }) {
 
         {/* Timeline scrubber */}
         <div className="flex items-center gap-2 flex-1">
-          <span className="text-xs text-gray-400 shrink-0">Step {currentStep}</span>
+          <span className="text-xs text-gray-500 shrink-0">Step {currentStep}</span>
           <input
             type="range"
             min={0}
@@ -323,7 +326,7 @@ function DemoViewer({ demoId }: { demoId: string }) {
             title="Timeline scrubber"
           />
           {totalSteps != null && (
-            <span className="text-xs text-gray-400 shrink-0">{totalSteps}</span>
+            <span className="text-xs text-gray-500 shrink-0">{totalSteps}</span>
           )}
         </div>
       </div>
@@ -337,16 +340,16 @@ export default function DemoPage() {
   const { id } = useParams<{ id?: string }>()
 
   return (
-    <div className="flex flex-col h-screen bg-gray-900 text-white">
+    <div className="flex flex-col h-screen bg-gray-50 text-gray-900">
       <header className="flex items-center gap-4 px-4 py-2 bg-gray-800 shrink-0 border-b border-gray-700">
-        <Link to="/" className="text-blue-400 hover:underline text-sm">
+        <Link to="/" className="retro-link text-sm">
           ← Back
         </Link>
-        <h1 className="text-lg font-semibold">
+        <h1 className="text-lg font-semibold uppercase tracking-wide">
           {id ? `Demo: ${id}` : 'Demo Viewer'}
         </h1>
         {id && (
-          <p className="text-gray-400 text-sm ml-auto">
+          <p className="text-gray-500 text-sm ml-auto">
             Arrow keys to pan · Use controls to play/pause
           </p>
         )}

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -39,17 +39,17 @@ export default function ExplorePage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="retro-page">
       <Header />
-      <main className="max-w-4xl mx-auto px-4 py-10">
+      <main className="retro-main">
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-2xl font-bold text-gray-900">Explore Simulations</h2>
+          <h2 className="retro-title text-xl">Explore Simulations</h2>
           <div className="flex items-center gap-2">
-            <label className="text-sm text-gray-600 font-medium">Status:</label>
+            <label className="text-xs uppercase font-bold text-gray-600">Status:</label>
             <select
               value={status}
               onChange={(e) => setStatus(e.target.value)}
-              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="retro-select"
             >
               {STATUS_OPTIONS.map((s) => (
                 <option key={s} value={s}>
@@ -61,7 +61,7 @@ export default function ExplorePage() {
         </div>
 
         {error && (
-          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-600 text-sm">
+          <div className="retro-panel mb-4 p-3 bg-red-50 border border-red-200 text-red-600 text-sm">
             {error}
           </div>
         )}
@@ -69,18 +69,18 @@ export default function ExplorePage() {
         {loading ? (
           <p className="text-gray-400">Loading…</p>
         ) : simulations.length === 0 ? (
-          <p className="text-gray-500">No public simulations found.</p>
+          <div className="retro-panel retro-empty-state">No public simulations found.</div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {simulations.map((sim) => (
               <div
                 key={sim.id}
-                className="bg-white rounded-xl border border-gray-100 shadow p-5 flex flex-col gap-2"
+                className="retro-panel p-5 flex flex-col gap-2"
               >
                 <div className="flex items-start justify-between">
-                  <h3 className="font-semibold text-gray-900">{sim.name}</h3>
+                  <h3 className="font-semibold text-gray-900 uppercase text-sm">{sim.name}</h3>
                   <span
-                    className={`text-xs px-2 py-0.5 rounded font-medium ${statusColors[sim.status ?? 'pending'] ?? 'bg-gray-100 text-gray-600'}`}
+                    className={`retro-badge text-xs px-2 py-0.5 rounded font-medium ${statusColors[sim.status ?? 'pending'] ?? 'bg-gray-100 text-gray-600'}`}
                   >
                     {sim.status ?? 'pending'}
                   </span>
@@ -93,7 +93,7 @@ export default function ExplorePage() {
                 </div>
                 <Link
                   to={`/simulate/${encodeURIComponent(sim.id)}`}
-                  className="mt-auto self-start bg-blue-600 hover:bg-blue-700 text-white text-sm px-4 py-1.5 rounded-lg transition-colors"
+                  className="mt-auto self-start retro-button retro-button-primary"
                 >
                   Observe
                 </Link>

--- a/frontend/src/pages/InvitesPage.tsx
+++ b/frontend/src/pages/InvitesPage.tsx
@@ -43,54 +43,60 @@ export default function InvitesPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="retro-page">
       <Header />
-      <main className="max-w-2xl mx-auto px-4 py-10">
-        <h2 className="text-2xl font-bold text-gray-900 mb-6">Pending Invites</h2>
-
-        {error && (
-          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-600 text-sm">
-            {error}
-          </div>
-        )}
-
-        {loading ? (
-          <p className="text-gray-400">Loading…</p>
-        ) : invites.length === 0 ? (
-          <p className="text-gray-500">
-            No pending invites.{' '}
-            <Link to="/dashboard" className="text-blue-600 hover:underline">
-              Back to dashboard
-            </Link>
+      <main className="retro-main max-w-3xl">
+        <div className="retro-panel p-6 md:p-8">
+          <h2 className="retro-title text-xl mb-5">Pending invites</h2>
+          <p className="retro-subtitle text-sm mb-6">
+            Accept to join instantly or decline to clear your queue.
           </p>
-        ) : (
-          <ul className="space-y-4">
-            {invites.map((invite) => (
-              <li key={invite.id} className="bg-white rounded-xl border border-gray-100 shadow p-5">
-                <div className="mb-1 font-semibold text-gray-900">{invite.simulation_name}</div>
-                {invite.invited_by && (
-                  <div className="text-sm text-gray-500 mb-4">
-                    Invited by <span className="font-medium">{invite.invited_by}</span>
+
+          {error && (
+            <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-600 text-sm">
+              {error}
+            </div>
+          )}
+
+          {loading ? (
+            <p className="text-gray-500">Loading…</p>
+          ) : invites.length === 0 ? (
+            <p className="retro-empty-state text-sm">
+              No pending invites.{' '}
+              <Link to="/dashboard" className="retro-link">
+                Return to dashboard
+              </Link>
+              .
+            </p>
+          ) : (
+            <ul className="space-y-4">
+              {invites.map((invite) => (
+                <li key={invite.id} className="retro-panel p-5">
+                  <div className="mb-1 font-bold uppercase tracking-wide text-sm">{invite.simulation_name}</div>
+                  {invite.invited_by && (
+                    <div className="text-xs text-gray-500 mb-4">
+                      Invited by <span className="font-bold">{invite.invited_by}</span>
+                    </div>
+                  )}
+                  <div className="flex gap-3">
+                    <button
+                      onClick={() => void handleAccept(invite)}
+                      className="retro-button retro-button-warm"
+                    >
+                      Accept
+                    </button>
+                    <button
+                      onClick={() => void handleDecline(invite.id)}
+                      className="retro-button retro-button-ghost"
+                    >
+                      Decline
+                    </button>
                   </div>
-                )}
-                <div className="flex gap-3">
-                  <button
-                    onClick={() => void handleAccept(invite)}
-                    className="bg-green-600 hover:bg-green-700 text-white text-sm px-4 py-1.5 rounded-lg transition-colors"
-                  >
-                    Accept
-                  </button>
-                  <button
-                    onClick={() => void handleDecline(invite.id)}
-                    className="bg-gray-200 hover:bg-gray-300 text-gray-700 text-sm px-4 py-1.5 rounded-lg transition-colors"
-                  >
-                    Decline
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </main>
     </div>
   )

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -12,70 +12,74 @@ export default function LandingPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <header className="bg-white shadow-sm">
-        <div className="max-w-5xl mx-auto px-4 py-5 flex items-center justify-between">
-          <h1 className="text-2xl font-bold text-gray-900">Generative Agents — Reverie</h1>
-          <nav className="flex gap-6">
-            <Link to="/simulate" className="text-blue-600 hover:text-blue-800 font-medium">
+    <div className="retro-page">
+      <header className="retro-header">
+        <div className="retro-header-inner flex flex-wrap items-center justify-between gap-3">
+          <h1 className="retro-brand">Reverie Pixel Town</h1>
+          <nav className="flex flex-wrap gap-2">
+            <Link to="/login" className="retro-navlink">
+              Sign in
+            </Link>
+            <Link to="/register" className="retro-navlink">
+              Register
+            </Link>
+            <Link to="/simulate" className="retro-navlink">
               Simulator
             </Link>
-            <Link to="/demo" className="text-blue-600 hover:text-blue-800 font-medium">
-              Demo Viewer
+            <Link to="/demo" className="retro-navlink">
+              Demo replay
             </Link>
           </nav>
         </div>
       </header>
 
-      {/* Hero */}
-      <main className="max-w-5xl mx-auto px-4 py-12">
-        <section className="text-center mb-12">
-          <h2 className="text-4xl font-bold text-gray-900 mb-4">
-            Generative Agent Simulations
-          </h2>
-          <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-            A sandbox environment for simulating believable human behavior using large language
-            models. Agents plan, reflect, converse, and act autonomously in a virtual world.
+      <main className="retro-main">
+        <section className="retro-panel p-6 md:p-8 mb-6">
+          <h2 className="retro-title mb-3">Pixel-style agent playground</h2>
+          <p className="retro-subtitle mb-5 max-w-3xl">
+            Follow three easy steps: create your simulation, drop characters, then watch your town
+            come alive in a retro map view.
           </p>
+          <div className="retro-steps max-w-3xl">
+            <div className="retro-step-item">
+              <span className="retro-step-count">1</span>
+              <p className="text-sm">Sign in and create a simulation from your dashboard.</p>
+            </div>
+            <div className="retro-step-item">
+              <span className="retro-step-count">2</span>
+              <p className="text-sm">Add or invite characters to your simulation.</p>
+            </div>
+            <div className="retro-step-item">
+              <span className="retro-step-count">3</span>
+              <p className="text-sm">Open live simulator or replay mode to observe behavior.</p>
+            </div>
+          </div>
         </section>
 
-        {/* Quick links */}
-        <section className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
-          <Link
-            to="/simulate"
-            className="block bg-white rounded-xl shadow p-6 hover:shadow-md transition-shadow border border-gray-100"
-          >
-            <h3 className="text-xl font-semibold text-gray-900 mb-2">Live Simulation</h3>
-            <p className="text-gray-600">
-              Watch agents navigate The Ville in real time, observe their decisions, and inspect
-              their memory and plans.
+        <section className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+          <Link to="/simulate" className="retro-panel block p-5">
+            <h3 className="retro-title text-lg mb-2">Live simulation</h3>
+            <p className="retro-subtitle text-sm mb-3">
+              Watch agents walk, chat, and plan in real time.
             </p>
-            <span className="mt-4 inline-block text-blue-600 font-medium">Open simulator →</span>
+            <span className="retro-link">Open live simulator</span>
           </Link>
 
-          <Link
-            to="/demo"
-            className="block bg-white rounded-xl shadow p-6 hover:shadow-md transition-shadow border border-gray-100"
-          >
-            <h3 className="text-xl font-semibold text-gray-900 mb-2">Demo Replay</h3>
-            <p className="text-gray-600">
-              Replay pre-recorded simulations with full playback controls — pause, rewind, and
-              inspect each simulation step.
+          <Link to="/demo" className="retro-panel block p-5">
+            <h3 className="retro-title text-lg mb-2">Demo replay</h3>
+            <p className="retro-subtitle text-sm mb-3">
+              Replay saved sessions with easy controls and timeline scrubber.
             </p>
-            <span className="mt-4 inline-block text-blue-600 font-medium">Open demo viewer →</span>
+            <span className="retro-link">Open replay viewer</span>
           </Link>
         </section>
 
-        {/* Create / Fork form */}
-        <section className="bg-white rounded-xl shadow p-8 border border-gray-100">
-          <h3 className="text-xl font-semibold text-gray-900 mb-6">
-            Create or Fork a Simulation
-          </h3>
+        <section className="retro-panel p-6 md:p-8">
+          <h3 className="retro-title text-lg mb-5">Quick simulation name tester</h3>
           <form onSubmit={handleCreate} className="space-y-4">
             <div>
-              <label htmlFor="sim-name" className="block text-sm font-medium text-gray-700 mb-1">
-                Simulation Name <span className="text-red-500">*</span>
+              <label htmlFor="sim-name" className="block text-xs font-bold uppercase mb-1">
+                Simulation name <span className="text-red-500">*</span>
               </label>
               <input
                 id="sim-name"
@@ -83,41 +87,35 @@ export default function LandingPage() {
                 required
                 value={simName}
                 onChange={(e) => setSimName(e.target.value)}
-                placeholder="e.g. my_ville_experiment"
-                className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="my_ville_experiment"
+                className="retro-input"
               />
             </div>
 
             <div>
-              <label htmlFor="fork-from" className="block text-sm font-medium text-gray-700 mb-1">
-                Fork From (optional)
+              <label htmlFor="fork-from" className="block text-xs font-bold uppercase mb-1">
+                Fork from (optional)
               </label>
               <input
                 id="fork-from"
                 type="text"
                 value={forkFrom}
                 onChange={(e) => setForkFrom(e.target.value)}
-                placeholder="e.g. base_the_ville_isabella_maria_klaus"
-                className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="base_the_ville..."
+                className="retro-input"
               />
-              <p className="mt-1 text-sm text-gray-500">
-                Leave blank to start a fresh simulation.
-              </p>
+              <p className="mt-1 text-xs text-gray-500">Leave empty to start fresh.</p>
             </div>
 
-            <button
-              type="submit"
-              className="bg-blue-600 hover:bg-blue-700 text-white font-medium px-6 py-2 rounded-lg transition-colors"
-            >
-              Create Simulation
+            <button type="submit" className="retro-button retro-button-warm">
+              Create simulation
             </button>
           </form>
         </section>
       </main>
 
-      {/* Footer */}
-      <footer className="mt-16 py-8 text-center text-sm text-gray-400">
-        Generative Agents — Stanford University Research Project
+      <footer className="py-6 text-center text-xs text-gray-500">
+        Reverie research playground
       </footer>
     </div>
   )

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -25,12 +25,15 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="bg-white rounded-xl shadow p-8 w-full max-w-md border border-gray-100">
-        <h2 className="text-2xl font-bold text-gray-900 mb-6">Sign in</h2>
+    <div className="retro-page flex items-center justify-center px-4 py-10">
+      <div className="retro-panel p-6 md:p-8 w-full max-w-lg">
+        <h2 className="retro-title mb-2">Sign in</h2>
+        <p className="retro-subtitle text-sm mb-5">
+          Step 1: Sign in. Step 2: create simulation. Step 3: watch your pixel town.
+        </p>
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
           <div>
-            <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="username" className="block text-xs font-bold uppercase mb-1">
               Username
             </label>
             <input
@@ -40,11 +43,11 @@ export default function LoginPage() {
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               placeholder="your_username"
-              className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="retro-input"
             />
           </div>
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="password" className="block text-xs font-bold uppercase mb-1">
               Password
             </label>
             <input
@@ -54,14 +57,14 @@ export default function LoginPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
-              className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="retro-input"
             />
           </div>
           {error && <p className="text-sm text-red-600">{error}</p>}
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white font-medium px-6 py-2 rounded-lg transition-colors"
+            className="w-full retro-button retro-button-primary"
           >
             {loading ? 'Signing in…' : 'Sign in'}
           </button>
@@ -78,7 +81,7 @@ export default function LoginPage() {
           <div className="mt-4 flex flex-col gap-3">
             <a
               href="/api/v1/auth/social/google/"
-              className="flex items-center justify-center gap-2 w-full border border-gray-300 bg-white hover:bg-gray-50 text-gray-700 font-medium px-4 py-2 rounded-lg transition-colors"
+              className="flex items-center justify-center gap-2 w-full retro-button retro-button-ghost no-underline"
             >
               <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
                 <path fill="#4285F4" d="M23.745 12.27c0-.79-.07-1.54-.19-2.27h-11.3v4.51h6.47c-.29 1.48-1.14 2.73-2.4 3.58v3h3.86c2.26-2.09 3.56-5.17 3.56-8.82z" />
@@ -90,7 +93,7 @@ export default function LoginPage() {
             </a>
             <a
               href="/api/v1/auth/social/github/"
-              className="flex items-center justify-center gap-2 w-full border border-gray-300 bg-white hover:bg-gray-50 text-gray-700 font-medium px-4 py-2 rounded-lg transition-colors"
+              className="flex items-center justify-center gap-2 w-full retro-button retro-button-ghost no-underline"
             >
               <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12" />
@@ -101,7 +104,7 @@ export default function LoginPage() {
         </div>
         <p className="mt-4 text-center text-sm text-gray-600">
           Don&apos;t have an account?{' '}
-          <Link to="/register" className="text-blue-600 hover:underline">
+          <Link to="/register" className="retro-link">
             Create account
           </Link>
         </p>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -34,12 +34,15 @@ export default function RegisterPage() {
     errors[field]?.[0] ?? null
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="bg-white rounded-xl shadow p-8 w-full max-w-md border border-gray-100">
-        <h2 className="text-2xl font-bold text-gray-900 mb-6">Create account</h2>
+    <div className="retro-page flex items-center justify-center px-4 py-8">
+      <div className="retro-panel p-6 md:p-8 w-full max-w-lg">
+        <h2 className="retro-title mb-3 text-center">Create account</h2>
+        <p className="retro-subtitle text-sm text-center mb-5">
+          Join the town in under one minute.
+        </p>
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
           <div>
-            <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="username" className="block text-xs font-bold uppercase mb-1">
               Username
             </label>
             <input
@@ -49,14 +52,14 @@ export default function RegisterPage() {
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               placeholder="your_username"
-              className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="retro-input"
             />
             {fieldError('username') && (
               <p className="mt-1 text-sm text-red-600">{fieldError('username')}</p>
             )}
           </div>
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="email" className="block text-xs font-bold uppercase mb-1">
               Email
             </label>
             <input
@@ -66,14 +69,14 @@ export default function RegisterPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
-              className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="retro-input"
             />
             {fieldError('email') && (
               <p className="mt-1 text-sm text-red-600">{fieldError('email')}</p>
             )}
           </div>
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="password" className="block text-xs font-bold uppercase mb-1">
               Password
             </label>
             <input
@@ -83,14 +86,14 @@ export default function RegisterPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
-              className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="retro-input"
             />
             {fieldError('password') && (
               <p className="mt-1 text-sm text-red-600">{fieldError('password')}</p>
             )}
           </div>
           <div>
-            <label htmlFor="password-confirm" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="password-confirm" className="block text-xs font-bold uppercase mb-1">
               Confirm password
             </label>
             <input
@@ -100,7 +103,7 @@ export default function RegisterPage() {
               value={passwordConfirm}
               onChange={(e) => setPasswordConfirm(e.target.value)}
               placeholder="••••••••"
-              className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="retro-input"
             />
             {fieldError('password_confirm') && (
               <p className="mt-1 text-sm text-red-600">{fieldError('password_confirm')}</p>
@@ -112,14 +115,14 @@ export default function RegisterPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white font-medium px-6 py-2 rounded-lg transition-colors"
+            className="w-full retro-button retro-button-primary"
           >
             {loading ? 'Creating account…' : 'Create account'}
           </button>
         </form>
-        <p className="mt-4 text-center text-sm text-gray-600">
+        <p className="mt-4 text-center text-xs text-gray-600">
           Already have an account?{' '}
-          <Link to="/login" className="text-blue-600 hover:underline">
+          <Link to="/login" className="retro-link">
             Sign in
           </Link>
         </p>

--- a/frontend/src/pages/ReplayPage.tsx
+++ b/frontend/src/pages/ReplayPage.tsx
@@ -116,15 +116,15 @@ export default function ReplayPage() {
       <header className="flex items-center gap-4 px-4 py-2 bg-gray-800 shrink-0 border-b border-gray-700">
         <Link
           to={`/simulate/${encodeURIComponent(simId)}`}
-          className="text-blue-400 hover:underline text-sm"
+          className="retro-link text-sm"
         >
           ← Back
         </Link>
-        <h1 className="text-lg font-semibold">Replay: {simId}</h1>
+        <h1 className="text-lg font-semibold uppercase tracking-wide">Replay: {simId}</h1>
         {sim?.status === 'running' && (
           <Link
             to={`/simulate/${encodeURIComponent(simId)}`}
-            className="ml-auto text-sm bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded transition-colors"
+            className="ml-auto retro-button retro-button-warm"
           >
             Watch Live
           </Link>
@@ -132,7 +132,7 @@ export default function ReplayPage() {
       </header>
 
       {/* Step info */}
-      <div className="shrink-0 px-4 py-2 bg-gray-800 border-b border-gray-700 text-xs text-gray-300 flex items-center gap-4">
+      <div className="shrink-0 px-4 py-2 bg-gray-800 border-b border-gray-700 text-xs text-gray-300 flex items-center gap-4 uppercase tracking-wide">
         <span>Step: <strong>{currentStep}</strong></span>
         {stepData?.sim_curr_time && (
           <span>Time: <strong>{stepData.sim_curr_time}</strong></span>
@@ -161,7 +161,7 @@ export default function ReplayPage() {
           {playing ? (
             <button
               onClick={() => setPlaying(false)}
-              className="bg-yellow-600 hover:bg-yellow-700 text-white text-sm px-4 py-1.5 rounded transition-colors"
+              className="retro-button text-sm bg-yellow-600 hover:bg-yellow-700 text-white"
             >
               Pause
             </button>
@@ -169,17 +169,17 @@ export default function ReplayPage() {
             <button
               onClick={() => setPlaying(true)}
               disabled={currentStep >= meta.last_step}
-              className="bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white text-sm px-4 py-1.5 rounded transition-colors"
+              className="retro-button retro-button-warm text-sm disabled:opacity-50"
             >
               Play
             </button>
           )}
-          <label className="text-xs text-gray-400">Speed:</label>
+          <label className="text-xs text-gray-400 uppercase tracking-wide">Speed:</label>
           {([1, 2, 5] as const).map((s) => (
             <button
               key={s}
               onClick={() => setSpeed(s)}
-              className={`text-xs px-3 py-1 rounded transition-colors ${speed === s ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-300 hover:bg-gray-600'}`}
+              className={`retro-button text-xs ${speed === s ? 'retro-button-primary' : 'retro-button-ghost text-gray-300 hover:bg-gray-600'}`}
             >
               {s}x
             </button>

--- a/frontend/src/pages/SimulatePage.tsx
+++ b/frontend/src/pages/SimulatePage.tsx
@@ -52,12 +52,14 @@ function SimulationPicker() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto p-8">
-      <h2 className="text-xl font-semibold mb-4 text-white">Select a Simulation</h2>
+    <div className="max-w-3xl mx-auto p-4 md:p-8">
+      <div className="retro-panel p-5">
+        <h2 className="retro-title text-lg mb-2">Pick a simulation</h2>
+        <p className="retro-subtitle text-sm mb-4">Choose one world to enter.</p>
       {simulations.length === 0 ? (
-        <p className="text-gray-400">
+        <p className="retro-empty-state">
           No simulations found. Create one from the{' '}
-          <Link to="/" className="text-blue-400 hover:underline">
+          <Link to="/" className="retro-link">
             home page
           </Link>
           .
@@ -68,11 +70,11 @@ function SimulationPicker() {
             <li key={sim.id}>
               <Link
                 to={`/simulate/${encodeURIComponent(sim.id)}`}
-                className="block bg-gray-800 rounded-lg px-5 py-4 hover:bg-gray-700 transition-colors"
+                className="block retro-panel px-4 py-3"
               >
-                <div className="font-medium text-white">{sim.name}</div>
+                <div className="font-semibold text-gray-900">{sim.name}</div>
                 {sim.curr_time && (
-                  <div className="text-sm text-gray-400 mt-1">Time: {sim.curr_time}</div>
+                  <div className="text-sm text-gray-600 mt-1">Time: {sim.curr_time}</div>
                 )}
                 <div className="text-sm text-gray-500 mt-1">
                   {sim.persona_names.length} agent{sim.persona_names.length !== 1 ? 's' : ''} · step{' '}
@@ -83,6 +85,7 @@ function SimulationPicker() {
           ))}
         </ul>
       )}
+      </div>
     </div>
   )
 }
@@ -95,10 +98,10 @@ function AgentCard({ agent }: { agent: Agent }) {
     : 'Unknown'
 
   return (
-    <div className="bg-gray-800 rounded-lg p-3 mb-3">
-      <div className="font-semibold text-white text-sm">{agent.name}</div>
+    <div className="retro-panel p-3 mb-3">
+      <div className="font-semibold text-gray-900 text-sm">{agent.name}</div>
       {agent.currently && (
-        <div className="text-xs text-gray-300 mt-1 leading-snug">{agent.currently}</div>
+        <div className="text-xs text-gray-600 mt-1 leading-snug">{agent.currently}</div>
       )}
       <div className="text-xs text-gray-500 mt-1">Location: {location}</div>
     </div>
@@ -177,24 +180,24 @@ function AdminToolbar({
   }
 
   return (
-    <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 flex items-center gap-3">
+    <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 flex items-center gap-3 flex-wrap">
       <span className="text-xs text-gray-400 font-medium uppercase">Admin</span>
       <Link
         to={`/simulate/${encodeURIComponent(sim.id)}/settings`}
-        className="text-xs bg-gray-600 hover:bg-gray-500 text-white px-3 py-1 rounded transition-colors"
+        className="retro-button retro-button-ghost text-xs py-1 px-3"
       >
         Settings
       </Link>
       <button
         onClick={() => void openDropModal()}
-        className="text-xs bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded transition-colors"
+        className="retro-button retro-button-primary text-xs py-1 px-3"
       >
         Drop Character
       </button>
       {sim.status !== 'running' && sim.status !== 'paused' && (
         <button
           onClick={() => void handleStart()}
-          className="text-xs bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded transition-colors"
+          className="retro-button retro-button-warm text-xs py-1 px-3"
         >
           Start
         </button>
@@ -202,7 +205,7 @@ function AdminToolbar({
       {sim.status === 'running' && (
         <button
           onClick={() => void handlePause()}
-          className="text-xs bg-yellow-600 hover:bg-yellow-700 text-white px-3 py-1 rounded transition-colors"
+          className="retro-button text-xs py-1 px-3 bg-yellow-600 hover:bg-yellow-700 text-white"
         >
           Pause
         </button>
@@ -210,7 +213,7 @@ function AdminToolbar({
       {sim.status === 'paused' && (
         <button
           onClick={() => void handleResume()}
-          className="text-xs bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded transition-colors"
+          className="retro-button retro-button-warm text-xs py-1 px-3"
         >
           Resume
         </button>
@@ -219,15 +222,15 @@ function AdminToolbar({
 
       {showDropModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-gray-800 rounded-xl p-6 w-full max-w-sm shadow-xl">
-            <h3 className="text-white font-semibold mb-4">Drop Character</h3>
+          <div className="retro-panel p-6 w-full max-w-sm shadow-xl">
+            <h3 className="text-gray-900 font-semibold mb-4">Drop Character</h3>
             {availableChars.length === 0 ? (
               <p className="text-gray-400 text-sm">No available characters.</p>
             ) : (
               <select
                 value={selectedCharId ?? ''}
                 onChange={(e) => setSelectedCharId(parseInt(e.target.value))}
-                className="w-full rounded-lg border border-gray-600 bg-gray-700 text-white px-3 py-2 mb-4"
+                className="retro-select w-full mb-4"
               >
                 <option value="">Select a character…</option>
                 {availableChars.map((c) => (
@@ -240,14 +243,14 @@ function AdminToolbar({
             <div className="flex gap-2 justify-end">
               <button
                 onClick={() => setShowDropModal(false)}
-                className="text-sm text-gray-400 hover:text-white px-3 py-1"
+                className="retro-button retro-button-ghost text-xs py-1 px-3"
               >
                 Cancel
               </button>
               <button
                 onClick={() => void handleDrop()}
                 disabled={!selectedCharId || loading}
-                className="text-sm bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white px-4 py-1 rounded"
+                className="retro-button retro-button-primary text-xs py-1 px-3"
               >
                 {loading ? 'Dropping…' : 'Drop'}
               </button>
@@ -348,19 +351,11 @@ function SimulationViewer({ simId }: { simId: string }) {
     return () => clearInterval(interval)
   }, [pollAgents, wsStatus])
 
-  if (error) {
-    return (
-      <div className="flex items-center justify-center flex-1 text-red-400">
-        Error: {error}
-      </div>
-    )
-  }
-
   const statusColors: Record<string, string> = {
     pending: 'bg-gray-600',
-    running: 'bg-green-600',
+    running: 'bg-green-600 text-gray-900',
     paused: 'bg-yellow-600',
-    completed: 'bg-blue-600',
+    completed: 'bg-blue-600 text-gray-900',
     failed: 'bg-red-600',
   }
 
@@ -379,7 +374,7 @@ function SimulationViewer({ simId }: { simId: string }) {
         {meta && (
           <div className="flex items-center gap-3 px-4 py-1 bg-gray-800 border-b border-gray-700 text-xs">
             <span
-              className={`inline-block px-2 py-0.5 rounded font-medium text-white ${statusColors[meta.status ?? 'pending'] ?? 'bg-gray-600'}`}
+              className={`inline-block px-2 py-0.5 retro-badge font-medium text-white ${statusColors[meta.status ?? 'pending'] ?? 'bg-gray-600'}`}
             >
               {meta.status ?? 'pending'}
             </span>
@@ -523,10 +518,10 @@ export default function SimulatePage() {
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-white">
       <header className="flex items-center gap-4 px-4 py-2 bg-gray-800 shrink-0 border-b border-gray-700">
-        <Link to="/" className="text-blue-400 hover:underline text-sm">
+        <Link to="/" className="retro-link text-sm">
           ← Back
         </Link>
-        <h1 className="text-lg font-semibold">
+        <h1 className="text-lg font-semibold uppercase tracking-wide">
           {id ? `Simulation: ${id}` : 'Simulation Viewer'}
         </h1>
         {id && (

--- a/frontend/src/pages/SimulationSettingsPage.tsx
+++ b/frontend/src/pages/SimulationSettingsPage.tsx
@@ -85,7 +85,7 @@ export default function SimulationSettingsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64 text-gray-400">
+      <div className="retro-page flex items-center justify-center h-64 text-gray-500">
         Loading…
       </div>
     )
@@ -94,57 +94,57 @@ export default function SimulationSettingsPage() {
   if (!meta) return null
 
   return (
-    <div className="min-h-screen bg-gray-900 text-white">
-      <header className="flex items-center gap-4 px-4 py-2 bg-gray-800 border-b border-gray-700">
-        <Link
-          to={`/simulate/${encodeURIComponent(simId)}`}
-          className="text-blue-400 hover:underline text-sm"
-        >
-          ← Back to Simulation
-        </Link>
-        <h1 className="text-lg font-semibold">Settings: {meta.name}</h1>
+    <div className="retro-page">
+      <header className="retro-header">
+        <div className="retro-header-inner flex flex-wrap items-center gap-2">
+          <Link
+            to={`/simulate/${encodeURIComponent(simId)}`}
+            className="retro-navlink"
+          >
+            Back to simulation
+          </Link>
+          <h1 className="retro-title text-base md:text-lg">Settings: {meta.name}</h1>
+        </div>
       </header>
 
-      <main className="max-w-2xl mx-auto px-4 py-8 space-y-8">
-        {/* Visibility */}
-        <section className="bg-gray-800 rounded-xl p-6">
-          <h2 className="text-base font-semibold mb-4">Visibility</h2>
-          <div className="flex items-center gap-4">
+      <main className="retro-main space-y-6 max-w-4xl">
+        <section className="retro-panel p-5">
+          <h2 className="retro-title text-base mb-3">Visibility</h2>
+          <div className="flex flex-wrap items-center gap-3">
             <select
               value={meta.visibility ?? 'private'}
               onChange={(e) => void handleVisibilityChange(e.target.value)}
-              className="rounded-lg border border-gray-600 bg-gray-700 text-white px-3 py-2"
+              className="retro-select"
             >
               <option value="private">Private</option>
               <option value="shared">Shared</option>
               <option value="public">Public</option>
             </select>
-            {visibilityError && <span className="text-red-400 text-sm">{visibilityError}</span>}
+            {visibilityError && <span className="text-sm text-red-500">{visibilityError}</span>}
           </div>
         </section>
 
-        {/* Members */}
-        <section className="bg-gray-800 rounded-xl p-6">
-          <h2 className="text-base font-semibold mb-4">Members</h2>
-          {removeError && <p className="text-red-400 text-sm mb-3">{removeError}</p>}
+        <section className="retro-panel p-5">
+          <h2 className="retro-title text-base mb-3">Members</h2>
+          {removeError && <p className="text-sm text-red-500 mb-3">{removeError}</p>}
           {members.length === 0 ? (
-            <p className="text-gray-400 text-sm">No members yet.</p>
+            <div className="retro-empty-state text-sm">No members yet.</div>
           ) : (
             <ul className="space-y-2 mb-4">
               {members.map((m) => (
                 <li
                   key={m.user_id}
-                  className="flex items-center justify-between bg-gray-700 rounded-lg px-4 py-2"
+                  className="border-2 border-gray-300 bg-white px-3 py-2 flex items-center justify-between gap-2"
                 >
                   <div>
-                    <span className="font-medium text-white text-sm">{m.username}</span>
-                    <span className="ml-2 text-xs text-gray-400">{m.role}</span>
-                    <span className="ml-2 text-xs text-gray-500">{m.status}</span>
+                    <span className="font-semibold text-sm">{m.username}</span>
+                    <span className="ml-2 text-xs text-gray-500 uppercase">{m.role}</span>
+                    <span className="ml-2 text-xs text-gray-500 uppercase">{m.status}</span>
                   </div>
                   {m.role !== 'admin' && (
                     <button
                       onClick={() => void handleRemove(m.user_id)}
-                      className="text-xs text-red-400 hover:text-red-300"
+                      className="retro-button retro-button-danger"
                     >
                       Remove
                     </button>
@@ -154,24 +154,20 @@ export default function SimulationSettingsPage() {
             </ul>
           )}
 
-          {/* Invite form */}
-          <form onSubmit={(e) => void handleInvite(e)} className="flex gap-2">
+          <form onSubmit={(e) => void handleInvite(e)} className="flex flex-col md:flex-row gap-2">
             <input
               required
               value={inviteUsername}
               onChange={(e) => setInviteUsername(e.target.value)}
               placeholder="Username to invite"
-              className="flex-1 rounded-lg border border-gray-600 bg-gray-700 text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="retro-input flex-1"
             />
-            <button
-              type="submit"
-              className="bg-blue-600 hover:bg-blue-700 text-white text-sm px-4 py-2 rounded-lg transition-colors"
-            >
+            <button type="submit" className="retro-button retro-button-primary">
               Invite
             </button>
           </form>
-          {inviteError && <p className="text-red-400 text-sm mt-2">{inviteError}</p>}
-          {inviteSuccess && <p className="text-green-400 text-sm mt-2">{inviteSuccess}</p>}
+          {inviteError && <p className="text-red-500 text-sm mt-2">{inviteError}</p>}
+          {inviteSuccess && <p className="text-green-700 text-sm mt-2">{inviteSuccess}</p>}
         </section>
       </main>
     </div>

--- a/frontend_server/translator/tests.py
+++ b/frontend_server/translator/tests.py
@@ -328,6 +328,22 @@ class ProcessEnvironmentTest(TestCase):
             content_type="application/json",
         )
 
+    def test_get_returns_405_not_500(self) -> None:
+        resp = self.client.get("/process_environment/")
+        self.assertEqual(resp.status_code, 405)
+
+    def test_invalid_json_returns_400(self) -> None:
+        resp = self.client.post(
+            "/process_environment/",
+            data="not-json",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_missing_required_fields_returns_400(self) -> None:
+        resp = self._post({"sim_code": "abc"})
+        self.assertEqual(resp.status_code, 400)
+
     def test_creates_environment_state_row(self) -> None:
         sim = _make_sim("env-post-sim")
         payload = {
@@ -376,6 +392,22 @@ class UpdateEnvironmentTest(TestCase):
             content_type="application/json",
         )
 
+    def test_get_returns_405_not_500(self) -> None:
+        resp = self.client.get("/update_environment/")
+        self.assertEqual(resp.status_code, 405)
+
+    def test_invalid_json_returns_400(self) -> None:
+        resp = self.client.post(
+            "/update_environment/",
+            data="not-json",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_missing_required_fields_returns_400(self) -> None:
+        resp = self._post({"step": 1})
+        self.assertEqual(resp.status_code, 400)
+
     def test_returns_movement_data_from_db(self) -> None:
         sim = _make_sim("move-sim")
         movements = {
@@ -399,6 +431,30 @@ class UpdateEnvironmentTest(TestCase):
         payload = {"sim_code": "move-empty-sim", "step": 99}
         resp = self._post(payload)
         self.assertEqual(resp.json()["<step>"], -1)
+
+
+class PathTesterUpdateTest(TestCase):
+    """Test: path_tester_update validates input and does not 500 on bad payloads."""
+
+    def test_get_returns_405_not_500(self) -> None:
+        resp = self.client.get("/path_tester_update/")
+        self.assertEqual(resp.status_code, 405)
+
+    def test_invalid_json_returns_400(self) -> None:
+        resp = self.client.post(
+            "/path_tester_update/",
+            data="not-json",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_missing_camera_returns_400(self) -> None:
+        resp = self.client.post(
+            "/path_tester_update/",
+            data=json.dumps({"not_camera": {}}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
 
 
 # ---------------------------------------------------------------------------

--- a/frontend_server/translator/views.py
+++ b/frontend_server/translator/views.py
@@ -11,6 +11,25 @@ from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
 
+def _parse_json_post(request):
+    """Validate POST + JSON body and return (data, error_response)."""
+    if request.method != "POST":
+        return None, JsonResponse({"detail": "Method not allowed."}, status=405)
+
+    if not request.body:
+        return None, JsonResponse({"detail": "Request body must be valid JSON."}, status=400)
+
+    try:
+        data = json.loads(request.body)
+    except json.JSONDecodeError:
+        return None, JsonResponse({"detail": "Request body must be valid JSON."}, status=400)
+
+    if not isinstance(data, dict):
+        return None, JsonResponse({"detail": "JSON body must be an object."}, status=400)
+
+    return data, None
+
+
 def spa_index(request):
     """Serve the React SPA index.html for all non-API, non-admin routes."""
     index_path = os.path.join(settings.REACT_DIST_DIR, "index.html")
@@ -31,15 +50,31 @@ def process_environment(request):
     RETURNS:
       HttpResponse: string confirmation message.
     """
-    data = json.loads(request.body)
-    step = data["step"]
-    sim_code = data["sim_code"]
-    environment = data["environment"]
+    data, error_response = _parse_json_post(request)
+    if error_response is not None:
+        return error_response
+    assert data is not None
+
+    step = data.get("step")
+    sim_code = data.get("sim_code")
+    environment = data.get("environment")
+
+    if step is None or sim_code is None or environment is None:
+        return JsonResponse(
+            {"detail": "step, sim_code, and environment are required."},
+            status=400,
+        )
+    if not isinstance(step, int):
+        return JsonResponse({"detail": "step must be an integer."}, status=400)
+    if not isinstance(sim_code, str) or not sim_code.strip():
+        return JsonResponse({"detail": "sim_code must be a non-empty string."}, status=400)
+    if not isinstance(environment, dict):
+        return JsonResponse({"detail": "environment must be an object."}, status=400)
 
     from translator.models import EnvironmentState, Simulation
 
     try:
-        sim = Simulation.objects.get(name=sim_code)
+        sim = Simulation.objects.get(name=sim_code.strip())
         EnvironmentState.objects.update_or_create(
             simulation=sim,
             step=step,
@@ -65,16 +100,27 @@ def update_environment(request):
     RETURNS:
       HttpResponse
     """
-    data = json.loads(request.body)
-    step = data["step"]
-    sim_code = data["sim_code"]
+    data, error_response = _parse_json_post(request)
+    if error_response is not None:
+        return error_response
+    assert data is not None
+
+    step = data.get("step")
+    sim_code = data.get("sim_code")
+
+    if step is None or sim_code is None:
+        return JsonResponse({"detail": "step and sim_code are required."}, status=400)
+    if not isinstance(step, int):
+        return JsonResponse({"detail": "step must be an integer."}, status=400)
+    if not isinstance(sim_code, str) or not sim_code.strip():
+        return JsonResponse({"detail": "sim_code must be a non-empty string."}, status=400)
 
     response_data: dict = {"<step>": -1}
 
     from translator.models import MovementRecord, Simulation
 
     try:
-        sim = Simulation.objects.get(name=sim_code)
+        sim = Simulation.objects.get(name=sim_code.strip())
         record = MovementRecord.objects.filter(simulation=sim, step=step).first()
         if record is not None:
             response_data = dict(record.persona_movements)
@@ -96,7 +142,14 @@ def path_tester_update(request):
     RETURNS:
       HttpResponse: string confirmation message.
     """
-    data = json.loads(request.body)
+    data, error_response = _parse_json_post(request)
+    if error_response is not None:
+        return error_response
+    assert data is not None
+
+    if "camera" not in data:
+        return JsonResponse({"detail": "camera is required."}, status=400)
+
     camera = data["camera"]
 
     from translator.models import RuntimeState


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Apply a consistent pixel-retro visual language across the React frontend.
- Introduce shared design tokens and reusable retro utility classes based on the required palette.
- Simplify the primary user journey with clearer step-oriented page content and stronger action affordances.
- Fix current lint warning by scoping out a known Phaser `this`-binding false positive.
- Fix all reproducible HTTP 500 endpoint responses in the local stack.

## What changed
- Added a global retro design system in `frontend/src/index.css` using:
  - `#77BEF0`
  - `#FFCB61`
  - `#FF894F`
  - `#EA5B6F`
- Restyled shared navigation/header with pixel-style buttons, badges, and branding.
- Refactored key pages to use a consistent retro theme and simpler UX copy/flow:
  - Landing, Login, Register
  - Dashboard, Characters, Create Character, Create Simulation
  - Explore, Invites, Simulation Settings
  - Simulate, Replay, Demo viewers
- Updated `frontend/eslint.config.js` with a file-scoped override for `src/game/GameCanvas.tsx` to suppress `react-hooks/unsupported-syntax` for Phaser lifecycle methods that require `this`.
- Hardened legacy game-loop endpoints in `frontend_server/translator/views.py`:
  - `/process_environment/`
  - `/update_environment/`
  - `/path_tester_update/`
  - Added method checks (POST only), JSON decoding guards, and payload validation to return `400/405` instead of `500` on malformed requests.
- Added regression tests in `frontend_server/translator/tests.py` to ensure malformed/invalid methods never regress to 500 on those endpoints.

## Validation
- `npm run lint` (pass)
- `npm run build` (pass)
- `python manage.py check` (pass)
- `python manage.py test translator.tests.DemosListTests translator.tests.DemoStepTests` (pass)
- `python manage.py test translator.tests.ProcessEnvironmentTest translator.tests.UpdateEnvironmentTest translator.tests.PathTesterUpdateTest` (pass)
- Runtime endpoint sweep over registered routes: 500 count = 0.

## Walkthrough artifacts
[retro_pixel_ui_walkthrough.mp4](https://cursor.com/agents/bc-9214bacb-5c46-49de-868d-31110b641de9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fretro_pixel_ui_walkthrough.mp4)
[endpoint_500_fix_validation.mp4](https://cursor.com/agents/bc-9214bacb-5c46-49de-868d-31110b641de9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fendpoint_500_fix_validation.mp4)
[Retro landing page](https://cursor.com/agents/bc-9214bacb-5c46-49de-868d-31110b641de9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fretro_landing_page.webp)
[Retro login page](https://cursor.com/agents/bc-9214bacb-5c46-49de-868d-31110b641de9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fretro_login_page.webp)
[Demo page without 500 error](https://cursor.com/agents/bc-9214bacb-5c46-49de-868d-31110b641de9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_page_no_500.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9214bacb-5c46-49de-868d-31110b641de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9214bacb-5c46-49de-868d-31110b641de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

