### PR TITLE
Fix core user flows and add comprehensive flow documentation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import RegisterPage from './pages/RegisterPage'
 import DashboardPage from './pages/DashboardPage'
 import CharactersPage from './pages/CharactersPage'
 import CreateCharacterPage from './pages/CreateCharacterPage'
+import EditCharacterPage from './pages/EditCharacterPage'
 import CreateSimulationPage from './pages/CreateSimulationPage'
 import SimulatePage from './pages/SimulatePage'
 import SimulationSettingsPage from './pages/SimulationSettingsPage'
@@ -50,6 +51,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <CreateCharacterPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/characters/:id/edit"
+            element={
+              <ProtectedRoute>
+                <EditCharacterPage />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/api/characters.ts
+++ b/frontend/src/api/characters.ts
@@ -8,6 +8,7 @@ export interface Character {
   backstory: string
   currently: string
   lifestyle: string
+  living_area: string
   daily_plan: string
   status: 'available' | 'in_simulation'
   simulation: string | null
@@ -33,6 +34,34 @@ export async function createCharacter(
   })
   if (!res.ok) {
     const err = (await res.json()) as Record<string, string[]>
+    throw err
+  }
+  return res.json() as Promise<Character>
+}
+
+export async function fetchCharacter(id: number): Promise<Character> {
+  const res = await apiFetch(`/characters/${id}/`)
+  if (!res.ok) {
+    const err = (await res.json()) as { detail?: string }
+    throw new Error(err.detail ?? `Failed to fetch character: ${res.status}`)
+  }
+  return res.json() as Promise<Character>
+}
+
+export async function updateCharacter(
+  id: number,
+  data: Partial<Omit<Character, 'id' | 'status' | 'simulation'>>,
+): Promise<Character> {
+  const res = await apiFetch(`/characters/${id}/`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) {
+    const err = (await res.json()) as Record<string, string[]> | { detail?: string }
+    if ('detail' in err && typeof err.detail === 'string') {
+      throw { non_field_errors: [err.detail] } as Record<string, string[]>
+    }
     throw err
   }
   return res.json() as Promise<Character>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,6 +4,7 @@
  */
 
 const API_BASE = '/api/v1'
+const REFRESH_TOKEN_STORAGE_KEY = 'ga_refresh_token'
 
 // In-memory access token (set by AuthContext)
 let _accessToken: string | null = null
@@ -16,14 +17,31 @@ export function getAccessToken(): string | null {
   return _accessToken
 }
 
-async function refreshAccessToken(): Promise<string | null> {
+export function setRefreshToken(token: string | null): void {
+  if (token) {
+    localStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, token)
+    return
+  }
+  localStorage.removeItem(REFRESH_TOKEN_STORAGE_KEY)
+}
+
+export function getRefreshToken(): string | null {
+  return localStorage.getItem(REFRESH_TOKEN_STORAGE_KEY)
+}
+
+export async function refreshAccessToken(): Promise<string | null> {
+  const refresh = getRefreshToken()
+  if (!refresh) return null
+
   const res = await fetch(`${API_BASE}/auth/token/refresh/`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    // refresh token is sent via cookie automatically
-    body: JSON.stringify({}),
+    body: JSON.stringify({ refresh }),
   })
-  if (!res.ok) return null
+  if (!res.ok) {
+    if (res.status === 401) setRefreshToken(null)
+    return null
+  }
   const data = (await res.json()) as { access: string }
   _accessToken = data.access
   return data.access

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,6 +1,6 @@
 /**
  * Auth context providing user state and auth operations.
- * Access token is stored in memory; refresh token is managed via cookie.
+ * Access token is stored in memory; refresh token is stored in localStorage.
  */
 
 import {
@@ -18,7 +18,12 @@ import {
   type UserData,
   type AuthTokens,
 } from '../api/auth'
-import { setAccessToken } from '../api/client'
+import {
+  getRefreshToken,
+  refreshAccessToken,
+  setAccessToken,
+  setRefreshToken,
+} from '../api/client'
 
 interface AuthContextValue {
   user: UserData | null
@@ -44,22 +49,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   function _setTokens(tokens: AuthTokens) {
     setAccessTokenState(tokens.access)
     setAccessToken(tokens.access)
+    setRefreshToken(tokens.refresh)
     setUser(tokens.user)
   }
 
-  // On mount, try to restore session via token refresh (cookie-based)
+  // On mount, try to restore session via stored refresh token.
   useEffect(() => {
     async function tryRestoreSession() {
       try {
-        const res = await fetch('/api/v1/auth/token/refresh/', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({}),
-        })
-        if (res.ok) {
-          const data = (await res.json()) as { access: string }
-          setAccessTokenState(data.access)
-          setAccessToken(data.access)
+        const access = await refreshAccessToken()
+        if (access) {
+          setAccessTokenState(access)
+          setAccessToken(access)
           const me = await apiFetchMe()
           setUser({ id: me.id, username: me.username, email: me.email })
         }
@@ -88,15 +89,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   async function logout() {
-    if (accessToken) {
+    const refresh = getRefreshToken()
+    if (refresh) {
       try {
-        await apiLogout(accessToken)
+        await apiLogout(refresh)
       } catch {
         // ignore
       }
     }
     setAccessTokenState(null)
     setAccessToken(null)
+    setRefreshToken(null)
     setUser(null)
   }
 

--- a/frontend/src/pages/EditCharacterPage.tsx
+++ b/frontend/src/pages/EditCharacterPage.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import Header from '../components/Header'
-import { createCharacter } from '../api/characters'
+import { fetchCharacter, updateCharacter } from '../api/characters'
 
-export default function CreateCharacterPage() {
+export default function EditCharacterPage() {
+  const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const [name, setName] = useState('')
   const [age, setAge] = useState('')
@@ -15,15 +16,46 @@ export default function CreateCharacterPage() {
   const [dailyPlan, setDailyPlan] = useState('')
   const [errors, setErrors] = useState<Record<string, string[]>>({})
   const [loading, setLoading] = useState(false)
+  const [initialLoading, setInitialLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+
+  const charId = id ? parseInt(id, 10) : NaN
+
+  useEffect(() => {
+    if (!id || Number.isNaN(charId)) {
+      setNotFound(true)
+      setInitialLoading(false)
+      return
+    }
+
+    fetchCharacter(charId)
+      .then((char) => {
+        setName(char.name)
+        setAge(char.age === null ? '' : String(char.age))
+        setTraits(char.traits)
+        setBackstory(char.backstory)
+        setCurrently(char.currently)
+        setLifestyle(char.lifestyle)
+        setLivingArea(char.living_area)
+        setDailyPlan(char.daily_plan)
+      })
+      .catch(() => {
+        setNotFound(true)
+      })
+      .finally(() => {
+        setInitialLoading(false)
+      })
+  }, [id, charId])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (Number.isNaN(charId)) return
     setErrors({})
     setLoading(true)
     try {
-      await createCharacter({
+      await updateCharacter(charId, {
         name,
-        age: age ? parseInt(age, 10) : undefined,
+        age: age ? parseInt(age, 10) : null,
         traits,
         backstory,
         currently,
@@ -36,7 +68,7 @@ export default function CreateCharacterPage() {
       if (err && typeof err === 'object') {
         setErrors(err as Record<string, string[]>)
       } else {
-        setErrors({ non_field_errors: ['Failed to create character'] })
+        setErrors({ non_field_errors: ['Failed to update character'] })
       }
     } finally {
       setLoading(false)
@@ -45,11 +77,42 @@ export default function CreateCharacterPage() {
 
   const fieldError = (field: string) => errors[field]?.[0] ?? null
 
+  if (initialLoading) {
+    return (
+      <div className="retro-page">
+        <Header />
+        <main className="retro-main max-w-2xl">
+          <p className="text-gray-500">Loading character…</p>
+        </main>
+      </div>
+    )
+  }
+
+  if (notFound) {
+    return (
+      <div className="retro-page">
+        <Header />
+        <main className="retro-main max-w-2xl">
+          <div className="retro-panel p-6">
+            <h2 className="retro-title mb-2">Character not found</h2>
+            <button
+              type="button"
+              onClick={() => navigate('/characters')}
+              className="retro-button retro-button-primary"
+            >
+              Back to characters
+            </button>
+          </div>
+        </main>
+      </div>
+    )
+  }
+
   return (
     <div className="retro-page">
       <Header />
       <main className="retro-main max-w-2xl">
-        <h2 className="retro-title mb-6">Create character</h2>
+        <h2 className="retro-title mb-6">Edit character</h2>
         <div className="retro-panel p-6">
           <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
             <div>
@@ -60,28 +123,28 @@ export default function CreateCharacterPage() {
                 required
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="e.g. Isabella Rodriguez"
                 className="retro-input"
               />
               {fieldError('name') && <p className="mt-1 text-sm text-red-600">{fieldError('name')}</p>}
             </div>
+
             <div>
               <label className="block text-xs font-bold uppercase mb-1">Age</label>
               <input
                 type="number"
                 value={age}
                 onChange={(e) => setAge(e.target.value)}
-                placeholder="e.g. 34"
                 min={0}
                 className="retro-input"
               />
+              {fieldError('age') && <p className="mt-1 text-sm text-red-600">{fieldError('age')}</p>}
             </div>
+
             <div>
               <label className="block text-xs font-bold uppercase mb-1">Traits</label>
               <textarea
                 value={traits}
                 onChange={(e) => setTraits(e.target.value)}
-                placeholder="e.g. friendly, artistic, curious about people"
                 rows={2}
                 className="retro-textarea"
               />
@@ -91,19 +154,15 @@ export default function CreateCharacterPage() {
               <textarea
                 value={backstory}
                 onChange={(e) => setBackstory(e.target.value)}
-                placeholder="e.g. Grew up in a small town and moved to the city to pursue a career in art"
                 rows={3}
                 className="retro-textarea"
               />
             </div>
             <div>
-              <label className="block text-xs font-bold uppercase mb-1">
-                Currently (what they&apos;re doing)
-              </label>
+              <label className="block text-xs font-bold uppercase mb-1">Currently</label>
               <textarea
                 value={currently}
                 onChange={(e) => setCurrently(e.target.value)}
-                placeholder="e.g. Running the Oak Hill Cafe and taking painting classes on Saturdays"
                 rows={2}
                 className="retro-textarea"
               />
@@ -113,7 +172,6 @@ export default function CreateCharacterPage() {
               <textarea
                 value={lifestyle}
                 onChange={(e) => setLifestyle(e.target.value)}
-                placeholder="e.g. Loves morning runs, cooking, and weekly book club meetings"
                 rows={2}
                 className="retro-textarea"
               />
@@ -123,7 +181,6 @@ export default function CreateCharacterPage() {
               <input
                 value={livingArea}
                 onChange={(e) => setLivingArea(e.target.value)}
-                placeholder="e.g. the_ville:double studio"
                 className="retro-input"
               />
             </div>
@@ -132,12 +189,12 @@ export default function CreateCharacterPage() {
               <textarea
                 value={dailyPlan}
                 onChange={(e) => setDailyPlan(e.target.value)}
-                placeholder="e.g. Wake up at 7am, run for 30 minutes, open the café at 9am..."
                 rows={3}
                 className="retro-textarea"
               />
             </div>
 
+            {errors.detail && <p className="text-sm text-red-600">{errors.detail[0]}</p>}
             {errors.non_field_errors && (
               <p className="text-sm text-red-600">{errors.non_field_errors[0]}</p>
             )}
@@ -148,7 +205,7 @@ export default function CreateCharacterPage() {
                 disabled={loading}
                 className="retro-button retro-button-primary"
               >
-                {loading ? 'Creating…' : 'Create Character'}
+                {loading ? 'Saving…' : 'Save changes'}
               </button>
               <button
                 type="button"

--- a/frontend_server/translator/character_views.py
+++ b/frontend_server/translator/character_views.py
@@ -26,6 +26,7 @@ def _character_data(char: Character) -> dict:
         "backstory": char.backstory,
         "currently": char.currently,
         "lifestyle": char.lifestyle,
+        "living_area": char.living_area,
         "daily_plan": char.daily_plan,
         "status": char.status,
         "simulation": char.simulation_id,
@@ -63,6 +64,7 @@ def characters_list(request: Request) -> Response:
         backstory=request.data.get("backstory", ""),
         currently=request.data.get("currently", ""),
         lifestyle=request.data.get("lifestyle", ""),
+        living_area=request.data.get("living_area", ""),
         daily_plan=request.data.get("daily_plan", ""),
     )
     return Response(_character_data(char), status=status.HTTP_201_CREATED)
@@ -108,7 +110,7 @@ def character_detail(request: Request, char_id: int) -> Response:
             )
         char.name = new_name
 
-    for field in ("traits", "backstory", "currently", "lifestyle", "daily_plan"):
+    for field in ("traits", "backstory", "currently", "lifestyle", "living_area", "daily_plan"):
         if field in request.data:
             setattr(char, field, request.data[field])
 

--- a/frontend_server/translator/migrations/0019_add_character_living_area.py
+++ b/frontend_server/translator/migrations/0019_add_character_living_area.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("translator", "0018_add_simulation_membership_model"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="character",
+            name="living_area",
+            field=models.CharField(blank=True, default="", max_length=500),
+        ),
+    ]

--- a/frontend_server/translator/models.py
+++ b/frontend_server/translator/models.py
@@ -74,6 +74,7 @@ class Character(models.Model):
     backstory = models.TextField(blank=True, default="")
     currently = models.TextField(blank=True, default="")
     lifestyle = models.TextField(blank=True, default="")
+    living_area = models.CharField(max_length=500, blank=True, default="")
     daily_plan = models.TextField(blank=True, default="")
     status = models.CharField(
         max_length=20,

--- a/frontend_server/translator/simulation_views.py
+++ b/frontend_server/translator/simulation_views.py
@@ -99,6 +99,7 @@ def drop_character(request: Request, sim_id: str) -> Response:
             "learned": char.backstory,
             "currently": char.currently,
             "lifestyle": char.lifestyle,
+            "living_area": char.living_area,
             "daily_plan_req": char.daily_plan,
         },
     )

--- a/frontend_server/translator/tests.py
+++ b/frontend_server/translator/tests.py
@@ -23,6 +23,7 @@ from django.test import TestCase
 from rest_framework_simplejwt.tokens import RefreshToken
 from translator.models import (
     ConceptNode,
+    Character,
     Demo,
     DemoMovement,
     EnvironmentState,
@@ -31,6 +32,7 @@ from translator.models import (
     Persona,
     PersonaScratch,
     Simulation,
+    SimulationMembership,
     SpatialMemory,
 )
 
@@ -186,6 +188,70 @@ class SimulationsListPostTests(AuthenticatedAPITestCase):
     def test_fork_from_nonexistent_returns_404(self) -> None:
         resp = self._post({"name": "orphan", "fork_from": "ghost-sim"})
         self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# Character CRUD + drop lifecycle (user flow critical path)
+# ---------------------------------------------------------------------------
+
+
+class CharacterFlowTests(AuthenticatedAPITestCase):
+    def test_create_edit_drop_character_preserves_living_area_and_schedule(self) -> None:
+        sim = _make_sim("char-flow-sim", owner=self.user)
+
+        # Ensure creator can perform admin actions on this simulation.
+        SimulationMembership.objects.create(
+            simulation=sim,
+            user=self.user,
+            role=SimulationMembership.Role.ADMIN,
+            status=SimulationMembership.MemberStatus.ACTIVE,
+        )
+
+        create_resp = self.client.post(
+            "/api/v1/characters/",
+            data=json.dumps(
+                {
+                    "name": "doctor_olivia",
+                    "age": 39,
+                    "traits": "empathetic, methodical",
+                    "currently": "on shift at clinic",
+                    "lifestyle": "daytime clinical schedule",
+                    "living_area": "the_ville:maple_apartment_2b",
+                    "daily_plan": "clinic rounds, lunch break, evening chart review",
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(create_resp.status_code, 201)
+        char_id = create_resp.json()["id"]
+        self.assertEqual(create_resp.json()["living_area"], "the_ville:maple_apartment_2b")
+
+        patch_resp = self.client.patch(
+            f"/api/v1/characters/{char_id}/",
+            data=json.dumps(
+                {
+                    "currently": "meeting patients and updating records",
+                    "daily_plan": "morning rounds, afternoon consults, evening notes",
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(patch_resp.status_code, 200)
+
+        drop_resp = self.client.post(
+            f"/api/v1/simulations/{sim.name}/drop/",
+            data=json.dumps({"character_id": char_id}),
+            content_type="application/json",
+        )
+        self.assertEqual(drop_resp.status_code, 200)
+
+        persona = Persona.objects.get(simulation=sim, name="doctor_olivia")
+        self.assertEqual(persona.living_area, "the_ville:maple_apartment_2b")
+        self.assertEqual(persona.daily_plan_req, "morning rounds, afternoon consults, evening notes")
+
+        char = Character.objects.get(pk=char_id)
+        self.assertEqual(char.status, Character.Status.IN_SIMULATION)
+        self.assertEqual(char.simulation_id, sim.id)
 
 
 # ---------------------------------------------------------------------------

--- a/tasks/user_flows_design_documentation.md
+++ b/tasks/user_flows_design_documentation.md
@@ -1,0 +1,326 @@
+# User Flows Design Documentation
+
+This document defines the canonical user flows in this repository and maps each flow to frontend routes, backend APIs, data contracts, and validation points.
+
+## Scope
+
+Covered components:
+- `frontend/` React SPA (user interaction surfaces)
+- `frontend_server/` Django + DRF API (auth, character, simulation lifecycle, replay, invites)
+- WebSocket live updates for simulation observation
+
+Primary goal:
+- Ensure the end-to-end flow works: login/register -> simulation selection/creation -> character creation/edit/drop -> simulation run/observe.
+
+---
+
+## Flow 1: Authentication and Session Lifecycle
+
+### User story
+As a user, I can register/login, stay authenticated across refreshes, and logout cleanly.
+
+### Entry points
+- `/register`
+- `/login`
+
+### APIs
+- `POST /api/v1/auth/register/`
+- `POST /api/v1/auth/login/`
+- `POST /api/v1/auth/token/refresh/`
+- `GET /api/v1/auth/me/`
+- `POST /api/v1/auth/logout/`
+
+### Design
+1. Register/login returns `{ access, refresh, user }`.
+2. Frontend stores:
+   - `access` in memory.
+   - `refresh` in `localStorage`.
+3. On app startup:
+   - If refresh token exists, call refresh endpoint.
+   - On success, fetch `/auth/me` and hydrate current user.
+4. On any API 401:
+   - `apiFetch` attempts one refresh retry automatically.
+5. Logout:
+   - Sends refresh token to `/auth/logout/`.
+   - Clears access + refresh tokens locally.
+
+### Failure handling
+- Invalid credentials -> login page error banner.
+- Expired/invalid refresh -> refresh token cleared; user remains unauthenticated.
+- Protected routes redirect to `/login`.
+
+---
+
+## Flow 2: Dashboard and Simulation Discovery
+
+### User story
+As an authenticated user, I can open my dashboard and discover my simulations and characters.
+
+### Route
+- `/dashboard`
+
+### APIs
+- `GET /api/v1/simulations/mine/`
+- `GET /api/v1/characters/`
+
+### Design
+1. Dashboard loads simulations + characters in parallel.
+2. Simulation cards expose:
+   - Observe -> `/simulate/:id`
+   - Settings -> `/simulate/:id/settings`
+3. Character cards show availability state:
+   - `available`
+   - `in_simulation`
+
+### Notes
+- This route is wrapped by `ProtectedRoute`.
+
+---
+
+## Flow 3: Create Simulation
+
+### User story
+As a user, I can create a new simulation world from a selected map and visibility mode.
+
+### Route
+- `/simulations/new`
+
+### APIs
+- `GET /api/v1/maps/`
+- `POST /api/v1/simulations/`
+
+### Request contract
+`POST /simulations/`:
+- `name` (required; `[A-Za-z0-9_-]+`)
+- `map_id` (optional, defaults to `the_ville`)
+- `visibility` (`private|public|shared`)
+- `fork_from` (optional)
+
+### Design
+1. Fetch map catalog.
+2. User selects map + visibility and provides simulation name.
+3. On create success, navigate to `/simulate/:id`.
+4. Backend creates admin membership for the creator.
+
+---
+
+## Flow 4: Character Authoring (Create/Edit)
+
+### User story
+As a user, I can author a character profile including profession/schedule/living context and edit it before dropping into a simulation.
+
+### Routes
+- `/characters`
+- `/characters/new`
+- `/characters/:id/edit`
+
+### APIs
+- `GET /api/v1/characters/`
+- `POST /api/v1/characters/`
+- `GET /api/v1/characters/:id/`
+- `PATCH /api/v1/characters/:id/`
+- `DELETE /api/v1/characters/:id/`
+
+### Character fields
+- `name`
+- `age`
+- `traits`
+- `backstory`
+- `currently` (occupation/current behavior context; e.g. doctor on clinic shift)
+- `lifestyle` (routine style)
+- `living_area` (where they live; e.g. `the_ville:maple_apartment_2b`)
+- `daily_plan` (schedule constraints/tasks)
+- `status`
+- `simulation`
+
+### Design constraints
+- Character names are unique per owner.
+- Characters in `in_simulation` state:
+  - cannot be edited
+  - cannot be deleted
+
+---
+
+## Flow 5: Drop Character into Simulation (Character -> Persona Projection)
+
+### User story
+As a simulation admin, I can drop one of my available characters into a simulation so it becomes an active agent persona.
+
+### Route surface
+- `/simulate/:id` (Admin toolbar -> "Drop Character")
+
+### API
+- `POST /api/v1/simulations/:id/drop/`
+
+### Request contract
+- `character_id` (required)
+
+### Projection mapping
+When dropping, backend creates `Persona` (idempotent per `simulation + name`) from `Character`:
+- `name` -> `name`
+- `traits` -> `innate`
+- `backstory` -> `learned`
+- `currently` -> `currently`
+- `lifestyle` -> `lifestyle`
+- `living_area` -> `living_area`
+- `daily_plan` -> `daily_plan_req`
+- plus derived first/last names and age
+
+### Access rules
+- Only simulation admins may drop.
+- Character must belong to requesting user.
+- Character must be `available`.
+
+### State transition
+- Character status becomes `in_simulation`.
+- Character `simulation` FK set to selected simulation.
+
+---
+
+## Flow 6: Simulation Runtime Control
+
+### User story
+As a simulation admin, I can start/pause/resume a simulation.
+
+### Route surface
+- `/simulate/:id` (Admin toolbar)
+
+### APIs
+- `POST /api/v1/simulations/:id/start/`
+- `POST /api/v1/simulations/:id/pause/`
+- `POST /api/v1/simulations/:id/resume/`
+
+### Rules
+- Start requires at least one persona in simulation.
+- Only admins can control runtime.
+- Valid state transitions:
+  - `pending|completed|failed -> running` (start)
+  - `running -> paused`
+  - `paused -> running`
+
+---
+
+## Flow 7: Observe Live Simulation
+
+### User story
+As a member/observer, I can watch agents and inspect details while simulation updates stream in.
+
+### Route
+- `/simulate/:id`
+
+### APIs
+- `GET /api/v1/simulations/:id/`
+- `GET /api/v1/simulations/:id/agents/`
+- `GET /api/v1/simulations/:id/agents/:agent_id/`
+
+### WebSocket
+- `ws://<host>/ws/simulations/:id/?token=<jwt>`
+
+### Design
+1. Load metadata + agents.
+2. Subscribe to WS for step updates.
+3. On WS update, refetch agents.
+4. Fallback polling every 5s when disconnected.
+5. Agent sidebar opens detail panel with:
+   - action
+   - chat partner
+   - daily requirement list
+   - recent concepts/memories
+
+---
+
+## Flow 8: Visibility, Collaboration, and Invites
+
+### User story
+As a simulation admin, I can control visibility and invite users. As an invitee, I can accept/decline.
+
+### Routes
+- `/simulate/:id/settings`
+- `/invites`
+- `/explore`
+
+### APIs
+- `PATCH /api/v1/simulations/:id/` (visibility)
+- `GET/POST /api/v1/simulations/:id/members/`
+- `DELETE /api/v1/simulations/:id/members/:user_id/`
+- `GET /api/v1/invites/`
+- `POST /api/v1/invites/:membership_id/accept/`
+- `POST /api/v1/invites/:membership_id/decline/`
+- `GET /api/v1/simulations/public/`
+
+### Roles
+- `admin`: full control
+- `observer`: view-only access
+- invite statuses: `invited`, `active`, `declined`
+
+---
+
+## Flow 9: Replay and Demo
+
+### User story
+As a user, I can replay historical movement states and inspect timeline progression.
+
+### Routes
+- `/simulate/:id/replay`
+- `/demo`
+- `/demo/:id`
+
+### APIs
+- `GET /api/v1/simulations/:id/replay/`
+- `GET /api/v1/simulations/:id/replay/:step/`
+- `GET /api/v1/demos/`
+- `GET /api/v1/demos/:id/step/:step/`
+
+### Design
+- Replay converts persisted movement records into canvas agent coordinates.
+- Demo viewer supports scrubbing + playback speed controls.
+
+---
+
+## End-to-End Sequence (Primary User Flow)
+
+### Scenario
+User logs in, creates simulation, creates doctor character with schedule/living info, edits profile, drops into simulation, starts sim, and observes agent behavior.
+
+### Sequence
+1. `POST /auth/login`
+2. `GET /simulations/mine`, `GET /characters`
+3. `POST /simulations`
+4. `POST /characters`
+5. `PATCH /characters/:id` (optional refinement)
+6. `POST /simulations/:id/drop`
+7. `POST /simulations/:id/start`
+8. `GET /simulations/:id/agents` + WS step updates
+9. Optional `POST /pause` / `POST /resume`
+
+---
+
+## Quality Gates for User Flow Correctness
+
+Minimum validation set:
+1. Auth register/login/refresh/logout works with token persistence.
+2. Character create/edit/delete permissions and state guards work.
+3. Drop creates persona with all mapped fields (`lifestyle`, `living_area`, `daily_plan_req`).
+4. Start/pause/resume enforce role + state constraints.
+5. Observe route renders agents and updates across poll/WS.
+6. Broken route checks:
+   - `/characters/:id/edit` must be resolvable.
+
+---
+
+## Data Model Notes (Flow-Critical)
+
+- `SimulationMembership` is the source of truth for permissions.
+- `Character` is user-authored pre-simulation profile.
+- `Persona` is simulation runtime identity projected from `Character`.
+- `EnvironmentState` and `MovementRecord` back live/replay positioning.
+
+---
+
+## Future Hardening Recommendations
+
+1. Enforce strict token validation in `SimulationConsumer.connect` (currently permissive).
+2. Add E2E browser tests (Playwright) for critical flow chain.
+3. Add server-side validation for `living_area` format (optional schema by map).
+4. Add audit logging for membership role changes and runtime controls.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix authentication session continuity by persisting refresh tokens and using them for startup/session refresh + 401 retries
- complete character-management flow by adding the missing `/characters/:id/edit` route and a full edit page
- extend character profile lifecycle with `living_area` across API/model/drop-to-persona mapping to support richer role/schedule/home context (e.g., doctor + schedule + lives-in)
- add comprehensive user flow design documentation at `tasks/user_flows_design_documentation.md`

## Changes
### Frontend
- Added `EditCharacterPage` and route wiring in `App.tsx`
- Added `fetchCharacter` and `updateCharacter` API helpers
- Extended character forms/types with `living_area`
- Fixed auth refresh lifecycle:
  - refresh token persisted in localStorage
  - startup session restore via refresh token
  - automatic 401 retry using refresh token
  - logout now blacklists refresh and clears local state

### Frontend server
- Added `Character.living_area` model field (+ migration `0019_add_character_living_area.py`)
- Exposed `living_area` in character list/detail/create/update APIs
- Propagated `living_area` into persona projection during drop flow (`daily_plan -> daily_plan_req` kept)
- Added integration test for create/edit/drop lifecycle preserving living area and schedule semantics

### Documentation
- Added `tasks/user_flows_design_documentation.md` with end-to-end flow definitions, endpoint contracts, lifecycle mappings, and quality gates.

## Validation plan
- run targeted frontend lint/type checks
- run targeted frontend_server checks + migration + tests for flow paths
- run API and UI end-to-end smoke for login -> simulation -> character create/edit/drop -> start/pause/resume -> observe
- include walkthrough artifacts after manual validation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc584c1c-43c5-47fc-8331-c5f8fb66b78f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc584c1c-43c5-47fc-8331-c5f8fb66b78f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

