### PR TITLE
Implement stateless serverless simulation step execution (Phase 5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,24 @@ KEY_OWNER=YourName
 POSTGRES_USER=freeguy
 POSTGRES_PASSWORD=changeme
 POSTGRES_DB=free_guy_db
+
+# ── Qdrant vector database ────────────────────────────────────────────────────
+# Self-hosted (docker-compose default):
+QDRANT_HOST=localhost
+QDRANT_PORT=6333
+# Qdrant Cloud (set both to use cloud instead of self-hosted):
+# QDRANT_URL=https://xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.us-east4-0.gcp.cloud.qdrant.io
+# QDRANT_API_KEY=your-qdrant-api-key-here
+
+# ── Redis / Django Channels ────────────────────────────────────────────────────
+# Self-hosted (docker-compose default):
+# REDIS_URL=redis://redis:6379
+# Upstash Redis (TLS, for Vercel / cloud deployments):
+# REDIS_URL=rediss://default:your-upstash-token@your-endpoint.upstash.io:6380
+# Set to 'false' on Vercel where Channels is replaced by SSE:
+# ENABLE_CHANNELS=false
+
+# ── Supabase (production PostgreSQL) ──────────────────────────────────────────
+# DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-0-us-east-1.pooler.supabase.com:6543/postgres
+# SUPABASE_URL=https://[project-ref].supabase.co
+# SUPABASE_ANON_KEY=your-supabase-anon-key-here

--- a/backend_server/reverie.py
+++ b/backend_server/reverie.py
@@ -662,6 +662,347 @@ class ReverieServer:
                 print("Error.")
 
 
+    # -----------------------------------------------------------------------
+    # Stateless stage methods — for Vercel serverless step execution
+    # -----------------------------------------------------------------------
+    # Each method loads ReverieServer state from DB, runs one cognitive stage
+    # for all personas, persists intermediate results to SimulationStepCache,
+    # and returns a JSON-serializable result dict.
+    #
+    # Execution order per step:
+    #   run_perceive → run_retrieve → run_plan → run_reflect → run_execute
+    # -----------------------------------------------------------------------
+
+    @classmethod
+    def _load_for_stage(cls, sim_code: str) -> "ReverieServer":
+        """Load a ReverieServer from DB without starting the polling loop.
+
+        Reconstructs personas_tile from PersonaScratch.curr_tile and restores
+        maze tile events from the saved game_obj_cleanup list.
+        """
+        init_django()
+
+        from translator.models import EnvironmentState as EnvironmentStateModel  # noqa: PLC0415
+        from translator.models import Persona as PersonaModel  # noqa: PLC0415
+        from translator.models import Simulation as SimulationModel  # noqa: PLC0415
+
+        try:
+            sim_db = SimulationModel.objects.get(name=sim_code)
+        except Exception as exc:
+            raise RuntimeError(f"Simulation '{sim_code}' not found in DB: {exc}") from exc
+
+        server: "ReverieServer" = cls.__new__(cls)
+        server.fork_sim_code = sim_code
+        server.sim_code = sim_code
+        server._db_sim = sim_db
+        server._db_agents = {}
+        server._db_memory_counts = {}
+        server.server_sleep = 1.0
+
+        def _naive(dt: Optional[Any]) -> Optional[datetime.datetime]:
+            if dt is None:
+                return None
+            return dt.replace(tzinfo=None) if getattr(dt, "tzinfo", None) else dt
+
+        server.start_time = _naive(sim_db.start_date) or datetime.datetime.now()
+        server.curr_time = _naive(sim_db.curr_time) or server.start_time
+        server.sec_per_step = sim_db.sec_per_step or 10
+        server.maze = Maze(sim_db.maze_name or "")
+        server.step = sim_db.step
+
+        # Load all active personas from DB.
+        server.personas = {}
+        server.personas_tile = {}
+
+        persona_rows = PersonaModel.objects.filter(simulation=sim_db, status="active")
+        for persona_row in persona_rows:
+            curr_persona = Persona(persona_id=persona_row.pk)
+            persona_name = curr_persona.name
+            server.personas[persona_name] = curr_persona
+            # personas_tile is reconstructed from the persisted curr_tile value.
+            tile = curr_persona.scratch.curr_tile
+            server.personas_tile[persona_name] = tuple(tile) if tile else (0, 0)  # type: ignore[arg-type]
+
+        # Restore persona events on maze tiles.
+        for persona_name, persona in server.personas.items():
+            tile = server.personas_tile[persona_name]
+            server.maze.tiles[tile[1]][tile[0]]["events"].add(persona.scratch.get_curr_event_and_desc())
+
+        # Clean up previous step's object events (turn them idle) using the
+        # game_obj_cleanup list saved from the last run_execute call.
+        for entry in (sim_db.game_obj_cleanup or []):
+            # Stored as [event_tuple, tile_xy] — tuples were serialized as lists.
+            event_tuple, tile_xy = entry
+            server.maze.turn_event_from_tile_idle(tuple(event_tuple), tuple(tile_xy))
+
+        return server
+
+    @classmethod
+    def _get_step_cache(cls, sim_code: str, step: int, stage: str) -> Optional[dict]:
+        """Load cached stage results from SimulationStepCache, or None if missing."""
+        from translator.models import Simulation as SimulationModel  # noqa: PLC0415
+        from translator.models import SimulationStepCache  # noqa: PLC0415
+
+        try:
+            sim_db = SimulationModel.objects.get(name=sim_code)
+            cache = SimulationStepCache.objects.get(simulation=sim_db, step=step, stage=stage)
+            return cache.data  # type: ignore[return-value]
+        except Exception:
+            return None
+
+    @classmethod
+    def _save_step_cache(cls, sim_code: str, step: int, stage: str, data: dict) -> None:
+        """Persist stage results to SimulationStepCache (upsert)."""
+        from translator.models import Simulation as SimulationModel  # noqa: PLC0415
+        from translator.models import SimulationStepCache  # noqa: PLC0415
+
+        sim_db = SimulationModel.objects.get(name=sim_code)
+        SimulationStepCache.objects.update_or_create(
+            simulation=sim_db,
+            step=step,
+            stage=stage,
+            defaults={"data": data},
+        )
+
+    @classmethod
+    def run_perceive(cls, sim_code: str) -> dict:
+        """Stage 1: Perceive environment for all personas.
+
+        Loads simulation state, runs perceive() for each persona (may include
+        LLM poignancy scoring calls), saves perceived node_ids to StepCache.
+
+        Returns: {"status": "ok", "step": N}
+        """
+        server = cls._load_for_stage(sim_code)
+        cache_data: dict = {}
+
+        for persona_name, persona in server.personas.items():
+            perceived_nodes = persona.perceive(server.maze)
+            # Serialize ConceptNodes as node_ids — they are reconstructed from DB
+            # in subsequent stages by looking up a_mem.id_to_node.
+            cache_data[persona_name] = {
+                "perceived_node_ids": [node.node_id for node in perceived_nodes],
+            }
+            # Persist new concept nodes created during perceive (poignancy scores).
+            persona.save()
+
+        cls._save_step_cache(sim_code, server.step, "perceive", cache_data)
+        return {"status": "ok", "step": server.step}
+
+    @classmethod
+    def run_retrieve(cls, sim_code: str) -> dict:
+        """Stage 2: Retrieve relevant memories for perceived events.
+
+        Runs Qdrant vector search for each persona's perceived events.
+        No LLM calls — fast (1–3s total).
+
+        Returns: {"status": "ok", "step": N}
+        """
+        server = cls._load_for_stage(sim_code)
+
+        perceive_cache = cls._get_step_cache(sim_code, server.step, "perceive")
+        if perceive_cache is None:
+            raise RuntimeError(f"perceive cache missing for sim '{sim_code}' step {server.step}")
+
+        cache_data: dict = {}
+
+        for persona_name, persona in server.personas.items():
+            persona_perceive = perceive_cache.get(persona_name, {})
+            perceived_node_ids: list = persona_perceive.get("perceived_node_ids", [])
+
+            # Reconstruct ConceptNode objects from persisted node_ids.
+            perceived_nodes = [
+                persona.a_mem.id_to_node[nid]
+                for nid in perceived_node_ids
+                if nid in persona.a_mem.id_to_node
+            ]
+
+            retrieved = persona.retrieve(perceived_nodes)
+
+            # Serialize retrieved dict as node_ids.
+            serialized: dict = {}
+            for description, val in retrieved.items():
+                curr_event = val.get("curr_event")
+                serialized[description] = {
+                    "curr_event_id": curr_event.node_id if curr_event else None,
+                    "event_ids": [n.node_id for n in val.get("events", [])],
+                    "thought_ids": [n.node_id for n in val.get("thoughts", [])],
+                }
+            cache_data[persona_name] = serialized
+
+        cls._save_step_cache(sim_code, server.step, "retrieve", cache_data)
+        return {"status": "ok", "step": server.step}
+
+    @classmethod
+    def run_plan(cls, sim_code: str) -> dict:
+        """Stage 3: Generate plans for all personas (LLM-intensive).
+
+        This is the slowest stage — typically 10–30s for 3 agents (2–5 LLM
+        calls each). Saves act_address (plan string) to StepCache.
+
+        Returns: {"status": "ok", "step": N}
+        """
+        server = cls._load_for_stage(sim_code)
+
+        perceive_cache = cls._get_step_cache(sim_code, server.step, "perceive")
+        retrieve_cache = cls._get_step_cache(sim_code, server.step, "retrieve")
+        if perceive_cache is None or retrieve_cache is None:
+            raise RuntimeError(f"perceive/retrieve cache missing for sim '{sim_code}' step {server.step}")
+
+        cache_data: dict = {}
+
+        for persona_name, persona in server.personas.items():
+            # Determine new_day flag (same logic as persona.move()).
+            new_day: Any = False
+            if not persona.scratch.curr_time:
+                new_day = "First day"
+            elif persona.scratch.curr_time.strftime("%A %B %d") != server.curr_time.strftime("%A %B %d"):
+                new_day = "New day"
+            persona.scratch.curr_time = server.curr_time
+
+            # Reconstruct retrieved dict from serialized node_ids.
+            raw_retrieve = retrieve_cache.get(persona_name, {})
+            retrieved: dict = {}
+            for description, val in raw_retrieve.items():
+                curr_event_id = val.get("curr_event_id")
+                retrieved[description] = {
+                    "curr_event": persona.a_mem.id_to_node.get(curr_event_id) if curr_event_id else None,
+                    "events": [
+                        persona.a_mem.id_to_node[nid]
+                        for nid in val.get("event_ids", [])
+                        if nid in persona.a_mem.id_to_node
+                    ],
+                    "thoughts": [
+                        persona.a_mem.id_to_node[nid]
+                        for nid in val.get("thought_ids", [])
+                        if nid in persona.a_mem.id_to_node
+                    ],
+                }
+
+            act_address = persona.plan(server.maze, server.personas, new_day, retrieved)
+            cache_data[persona_name] = {
+                "act_address": act_address,
+                "new_day": new_day,
+            }
+            # Persist scratch changes (schedule, action fields) from plan.
+            persona.save()
+
+        cls._save_step_cache(sim_code, server.step, "plan", cache_data)
+        return {"status": "ok", "step": server.step}
+
+    @classmethod
+    def run_reflect(cls, sim_code: str) -> dict:
+        """Stage 4: Reflection — create new thoughts if importance threshold met.
+
+        Conditionally calls LLMs (0–3 calls per persona). Fast if no reflection
+        is triggered; up to 20s if all agents reflect.
+
+        Returns: {"status": "ok", "step": N}
+        """
+        server = cls._load_for_stage(sim_code)
+
+        for persona_name, persona in server.personas.items():
+            persona.reflect()
+            persona.save()
+
+        cls._save_step_cache(sim_code, server.step, "reflect", {"completed": True})
+        return {"status": "ok", "step": server.step}
+
+    @classmethod
+    def run_execute(cls, sim_code: str) -> dict:
+        """Stage 5: Execute plans — pathfinding and movement finalization.
+
+        No LLM calls. Computes next tile for each persona, writes MovementRecord
+        to DB, updates Simulation.step and Simulation.game_obj_cleanup.
+
+        Returns: {"movements": {persona_name: {movement, pronunciatio, description, chat}},
+                  "meta": {"curr_time": "..."}, "step": N}
+        """
+        server = cls._load_for_stage(sim_code)
+
+        plan_cache = cls._get_step_cache(sim_code, server.step, "plan")
+        if plan_cache is None:
+            raise RuntimeError(f"plan cache missing for sim '{sim_code}' step {server.step}")
+
+        # Apply env positions — use latest EnvironmentState for the current step.
+        from translator.models import EnvironmentState as EnvironmentStateModel  # noqa: PLC0415
+
+        env_row = EnvironmentStateModel.objects.filter(
+            simulation=server._db_sim, step=server.step
+        ).first()
+        if env_row:
+            new_env = env_row.agent_positions or {}
+            for persona_name, persona in server.personas.items():
+                curr_tile = server.personas_tile[persona_name]
+                new_tile_data = new_env.get(persona_name, {})
+                new_tile = (int(new_tile_data.get("x", curr_tile[0])), int(new_tile_data.get("y", curr_tile[1])))
+                server.personas_tile[persona_name] = new_tile
+                server.maze.remove_subject_events_from_tile(persona.name, curr_tile)
+                server.maze.add_event_from_tile(persona.scratch.get_curr_event_and_desc(), new_tile)
+
+        # Track new object events for cleanup at next step start.
+        new_game_obj_cleanup: list = []
+
+        movements: dict = {"persona": {}, "meta": {}}
+        for persona_name, persona in server.personas.items():
+            persona_plan = plan_cache.get(persona_name, {})
+            act_address = persona_plan.get("act_address")
+
+            new_tile = server.personas_tile[persona_name]
+            if not persona.scratch.planned_path:
+                event_desc = persona.scratch.get_curr_obj_event_and_desc()
+                new_game_obj_cleanup.append([list(event_desc), list(new_tile)])
+                server.maze.add_event_from_tile(event_desc, new_tile)
+                blank = (event_desc[0], None, None, None)
+                server.maze.remove_event_from_tile(blank, new_tile)
+
+            next_tile, pronunciatio, description = persona.execute(server.maze, server.personas, act_address)
+            movements["persona"][persona_name] = {
+                "movement": next_tile,
+                "pronunciatio": pronunciatio,
+                "description": description,
+                "chat": persona.scratch.chat,
+            }
+            persona.save()
+
+        movements["meta"]["curr_time"] = server.curr_time.strftime("%B %d, %Y, %H:%M:%S")
+
+        next_step = server.step + 1
+        next_time = server.curr_time + datetime.timedelta(seconds=server.sec_per_step)
+
+        from django.db import transaction  # noqa: PLC0415
+        from django.utils import timezone  # noqa: PLC0415
+        from translator.models import MovementRecord as MovementRecordModel  # noqa: PLC0415
+        from translator.models import Simulation as SimulationModel  # noqa: PLC0415
+
+        curr_time_aware = timezone.make_aware(server.curr_time) if server.curr_time.tzinfo is None else server.curr_time
+        next_time_aware = timezone.make_aware(next_time) if next_time.tzinfo is None else next_time
+
+        with transaction.atomic():
+            MovementRecordModel.objects.update_or_create(
+                simulation=server._db_sim,
+                step=server.step,
+                defaults={
+                    "sim_curr_time": curr_time_aware,
+                    "persona_movements": movements,
+                },
+            )
+            SimulationModel.objects.filter(pk=server._db_sim.pk).update(
+                step=next_step,
+                curr_time=next_time_aware,
+                status="running",
+                game_obj_cleanup=new_game_obj_cleanup,
+            )
+            set_runtime_state("curr_sim_code", {"sim_code": sim_code})
+            set_runtime_state("curr_step", {"step": next_step})
+
+        return {
+            "movements": movements,
+            "step": server.step,
+            "next_step": next_step,
+        }
+
+
 if __name__ == "__main__":
     origin = input("Enter the name of the forked simulation: ").strip()
     target = input("Enter the name of the new simulation: ").strip()

--- a/backend_server/utils/qdrant_utils.py
+++ b/backend_server/utils/qdrant_utils.py
@@ -12,6 +12,10 @@ from qdrant_client import QdrantClient
 from qdrant_client.http import models
 
 # ── Configuration ──────────────────────────────────────────────────────────────
+# For Qdrant Cloud: set QDRANT_URL (e.g. https://xyz.qdrant.io) and QDRANT_API_KEY.
+# For self-hosted: set QDRANT_HOST and QDRANT_PORT (defaults: localhost:6333).
+QDRANT_URL = os.environ.get("QDRANT_URL", "")
+QDRANT_API_KEY = os.environ.get("QDRANT_API_KEY", "")
 QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost")
 QDRANT_PORT = int(os.environ.get("QDRANT_PORT", "6333"))
 EMBEDDING_DIMENSION = int(os.environ.get("EMBEDDING_DIMENSION", "1536"))
@@ -22,10 +26,17 @@ _client: Optional[QdrantClient] = None
 
 
 def _get_client() -> QdrantClient:
-    """Return (and lazily create) the module-level Qdrant client singleton."""
+    """Return (and lazily create) the module-level Qdrant client singleton.
+
+    Uses QDRANT_URL + QDRANT_API_KEY for Qdrant Cloud, or QDRANT_HOST + QDRANT_PORT
+    for a self-hosted instance.
+    """
     global _client
     if _client is None:
-        _client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+        if QDRANT_URL:
+            _client = QdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY or None)
+        else:
+            _client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
     return _client
 
 

--- a/frontend/api/simulations/[id]/stream.ts
+++ b/frontend/api/simulations/[id]/stream.ts
@@ -1,0 +1,98 @@
+/**
+ * Vercel Edge Function — SSE stream for simulation movement updates.
+ *
+ * Polls the Django REST API for new MovementRecord rows and forwards them
+ * as Server-Sent Events to subscribed frontend clients.
+ *
+ * Runtime: Vercel Edge (V8, no Node.js built-ins).
+ * Path: /api/simulations/:id/stream
+ *
+ * Authentication: Reads the Authorization header from the incoming request
+ * and forwards it to the Django REST API, so only authenticated users can
+ * subscribe to a simulation stream.
+ */
+
+export const runtime = 'edge'
+
+const POLL_INTERVAL_MS = 2000
+// Maximum stream duration to prevent runaway edge functions (10 minutes).
+const MAX_DURATION_MS = 10 * 60 * 1000
+
+/** Fetch the latest MovementRecord for the simulation from the Django REST API. */
+async function fetchLatestMovement(
+  apiBase: string,
+  simId: string,
+  afterStep: number,
+  authHeader: string | null,
+): Promise<{ step: number; sim_curr_time: string | null; persona_movements: unknown } | null> {
+  const url = `${apiBase}/api/v1/simulations/${encodeURIComponent(simId)}/movements/latest/?after_step=${afterStep}`
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (authHeader) headers['Authorization'] = authHeader
+
+  try {
+    const res = await fetch(url, { headers })
+    if (!res.ok) return null
+    const data = (await res.json()) as {
+      step?: number
+      sim_curr_time?: string | null
+      persona_movements?: unknown
+    }
+    if (data.step == null) return null
+    return {
+      step: data.step,
+      sim_curr_time: data.sim_curr_time ?? null,
+      persona_movements: data.persona_movements,
+    }
+  } catch {
+    return null
+  }
+}
+
+export async function GET(req: Request, { params }: { params: { id: string } }): Promise<Response> {
+  const { id: simId } = params
+
+  // Forward the Authorization header so the Django API can authenticate the request.
+  const authHeader = req.headers.get('Authorization')
+
+  // Determine Django API base URL from environment (set in Vercel project settings).
+  // Defaults to same origin (works when frontend + API share the same Vercel project).
+  const apiBase = (process.env['DJANGO_API_BASE_URL'] ?? '').replace(/\/$/, '')
+
+  const encoder = new TextEncoder()
+  let lastStep = -1
+  const startedAt = Date.now()
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      // Send an initial "connected" event so the client knows the stream is live.
+      controller.enqueue(encoder.encode('event: connected\ndata: {}\n\n'))
+
+      while (true) {
+        // Stop the stream after MAX_DURATION_MS to free edge resources.
+        if (Date.now() - startedAt > MAX_DURATION_MS) {
+          controller.enqueue(encoder.encode('event: timeout\ndata: {}\n\n'))
+          controller.close()
+          return
+        }
+
+        const record = await fetchLatestMovement(apiBase, simId, lastStep, authHeader)
+        if (record !== null) {
+          lastStep = record.step
+          const payload = JSON.stringify(record)
+          controller.enqueue(encoder.encode(`data: ${payload}\n\n`))
+        }
+
+        // Poll every POLL_INTERVAL_MS milliseconds.
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+      }
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}

--- a/frontend/src/api/simulations.ts
+++ b/frontend/src/api/simulations.ts
@@ -352,3 +352,77 @@ export async function fetchAgentDetail(simId: string, agentId: string): Promise<
   if (!res.ok) throw new Error(`Failed to fetch agent detail: ${res.status}`)
   return res.json() as Promise<AgentDetail>
 }
+
+// ─── Serverless step orchestration (Phase 5) ─────────────────────────────────
+
+export interface AgentPosition {
+  x: number
+  y: number
+}
+
+export interface StepMovements {
+  persona: Record<string, { movement: [number, number]; pronunciatio: string; description: string; chat: unknown }>
+  meta: { curr_time: string }
+}
+
+export interface StepResult {
+  status?: string
+  step: number
+  next_step?: number
+  movements?: StepMovements
+}
+
+/** Submit current agent positions as EnvironmentState for the current step. */
+export async function submitEnvironmentState(
+  simId: string,
+  step: number,
+  agentPositions: Record<string, AgentPosition>,
+): Promise<void> {
+  const res = await apiFetch(`/simulations/${encodeURIComponent(simId)}/state/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ step, agent_positions: agentPositions }),
+  })
+  if (!res.ok) throw new Error(`submitEnvironmentState failed: ${res.status}`)
+}
+
+const STAGES = ['perceive', 'retrieve', 'plan', 'reflect', 'execute'] as const
+type Stage = (typeof STAGES)[number]
+
+/** Run a single cognitive stage for all agents. */
+export async function runStepStage(simId: string, stage: Stage): Promise<StepResult> {
+  const res = await apiFetch(
+    `/simulations/${encodeURIComponent(simId)}/step/${stage}/`,
+    { method: 'POST' },
+  )
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Stage '${stage}' failed (${res.status}): ${body}`)
+  }
+  return res.json() as Promise<StepResult>
+}
+
+/**
+ * Run a complete simulation step (all 5 cognitive stages in sequence).
+ * Returns the movement data from the execute stage.
+ *
+ * @param simId - Simulation name/id
+ * @param agentPositions - Current frontend agent positions (from Phaser canvas)
+ * @param step - Current step number (used when submitting environment state)
+ * @param onStageComplete - Optional callback called after each stage completes
+ */
+export async function runSimulationStep(
+  simId: string,
+  agentPositions: Record<string, AgentPosition>,
+  step: number,
+  onStageComplete?: (stage: Stage, result: StepResult) => void,
+): Promise<StepResult> {
+  await submitEnvironmentState(simId, step, agentPositions)
+
+  let lastResult: StepResult = { step }
+  for (const stage of STAGES) {
+    lastResult = await runStepStage(simId, stage)
+    onStageComplete?.(stage, lastResult)
+  }
+  return lastResult
+}

--- a/frontend/src/hooks/useSimulationSSE.ts
+++ b/frontend/src/hooks/useSimulationSSE.ts
@@ -1,0 +1,105 @@
+/**
+ * Hook for live Server-Sent Events connection to a simulation.
+ *
+ * Connects to the Vercel Edge Function SSE endpoint at
+ * /api/simulations/:id/stream, which polls the DB for new MovementRecord rows
+ * and forwards them as SSE events.
+ *
+ * Replaces useSimulationWebSocket.ts — same interface, different transport.
+ */
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { getAccessToken } from '../api/client'
+
+export interface StepUpdatePayload {
+  step?: number
+  sim_curr_time?: string
+  persona_movements?: Record<string, unknown>
+  // Legacy field names kept for backwards compatibility with existing consumers
+  agents?: Record<string, unknown>
+}
+
+interface UseSimulationSSEOptions {
+  simId: string
+  onStepUpdate: (payload: StepUpdatePayload) => void
+  onForbidden: () => void
+  onAuthError: () => void
+}
+
+export type SseStatus = 'connecting' | 'connected' | 'disconnected'
+
+export function useSimulationSSE({
+  simId,
+  onStepUpdate,
+  onForbidden,
+  onAuthError,
+}: UseSimulationSSEOptions) {
+  const [sseStatus, setSseStatus] = useState<SseStatus>('disconnected')
+  const esRef = useRef<EventSource | null>(null)
+  const backoffRef = useRef(1000)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const unmountedRef = useRef(false)
+
+  const connect = useCallback(() => {
+    if (unmountedRef.current) return
+
+    const token = getAccessToken()
+    if (!token) {
+      onAuthError()
+      return
+    }
+
+    setSseStatus('connecting')
+
+    // The SSE edge function is at /api/simulations/:id/stream.
+    // We pass the JWT as a query parameter because EventSource does not support
+    // custom headers. The edge function forwards it to the Django API.
+    const url = `/api/simulations/${encodeURIComponent(simId)}/stream?token=${encodeURIComponent(token)}`
+    const es = new EventSource(url)
+    esRef.current = es
+
+    es.addEventListener('connected', () => {
+      if (unmountedRef.current) return
+      setSseStatus('connected')
+      backoffRef.current = 1000
+    })
+
+    es.onmessage = (event) => {
+      if (unmountedRef.current) return
+      try {
+        const data = JSON.parse(event.data as string) as StepUpdatePayload
+        onStepUpdate(data)
+      } catch {
+        // ignore malformed messages
+      }
+    }
+
+    es.addEventListener('timeout', () => {
+      // Edge function stream expired — reconnect immediately.
+      es.close()
+      if (!unmountedRef.current) connect()
+    })
+
+    es.onerror = () => {
+      if (unmountedRef.current) return
+      es.close()
+      setSseStatus('disconnected')
+      const delay = Math.min(backoffRef.current, 30000)
+      backoffRef.current = Math.min(backoffRef.current * 2, 30000)
+      reconnectTimerRef.current = setTimeout(connect, delay)
+    }
+  }, [simId, onStepUpdate, onForbidden, onAuthError])
+
+  useEffect(() => {
+    unmountedRef.current = false
+    const timer = setTimeout(connect, 0)
+    return () => {
+      unmountedRef.current = true
+      clearTimeout(timer)
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current)
+      esRef.current?.close()
+    }
+  }, [connect])
+
+  return { wsStatus: sseStatus }
+}

--- a/frontend/src/pages/SimulatePage.tsx
+++ b/frontend/src/pages/SimulatePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import GameCanvas from '../game/GameCanvas'
 import {
@@ -10,13 +10,15 @@ import {
   startSimulation,
   pauseSimulation,
   resumeSimulation,
+  runSimulationStep,
   type Agent,
   type AgentDetail,
+  type AgentPosition,
   type SimulationMeta,
 } from '../api/simulations'
 import { fetchCharacters, type Character } from '../api/characters'
 import { useAuth } from '../context/AuthContext'
-import { useSimulationWebSocket } from '../hooks/useSimulationWebSocket'
+import { useSimulationSSE } from '../hooks/useSimulationSSE'
 
 const POLL_INTERVAL_MS = 5000
 
@@ -275,6 +277,9 @@ function SimulationViewer({ simId }: { simId: string }) {
   const [wsError, setWsError] = useState<string | null>(null)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
   const [agentDetail, setAgentDetail] = useState<AgentDetail | null>(null)
+  // Step orchestration loop (Vercel serverless mode)
+  const stepLoopActiveRef = useRef(false)
+  const agentPositionsRef = useRef<Record<string, AgentPosition>>({})
 
   const loadMeta = useCallback(() => {
     fetchSimulation(simId)
@@ -307,7 +312,7 @@ function SimulationViewer({ simId }: { simId: string }) {
     void pollAgents()
   }, [pollAgents])
 
-  const { wsStatus } = useSimulationWebSocket({
+  const { wsStatus } = useSimulationSSE({
     simId,
     onStepUpdate: handleStepUpdate,
     onForbidden: () => setWsError('Access denied'),
@@ -338,18 +343,77 @@ function SimulationViewer({ simId }: { simId: string }) {
     return () => window.removeEventListener('keydown', handler)
   }, [selectAgent])
 
+  // Keep agentPositionsRef in sync with current agent locations so the step
+  // loop can submit accurate positions to the EnvironmentState API.
+  useEffect(() => {
+    const positions: Record<string, AgentPosition> = {}
+    for (const agent of agents) {
+      if (agent.location) {
+        positions[agent.name] = { x: agent.location.x, y: agent.location.y }
+      }
+    }
+    agentPositionsRef.current = positions
+  }, [agents])
+
   // Initial load
   useEffect(() => {
     loadMeta()
     pollAgents()
   }, [simId, loadMeta, pollAgents])
 
-  // Polling (fallback when WebSocket is not connected)
+  // Polling (fallback when SSE is not connected)
   useEffect(() => {
     if (wsStatus === 'connected') return
     const interval = setInterval(pollAgents, POLL_INTERVAL_MS)
     return () => clearInterval(interval)
   }, [pollAgents, wsStatus])
+
+  // ── Step orchestration loop (Vercel serverless mode) ────────────────────
+  // When the simulation is running and this browser tab is the owner,
+  // we drive the cognitive pipeline by calling each stage API in sequence.
+  // The SSE stream (or polling fallback) delivers movements to GameCanvas.
+  const runStepLoop = useCallback(async () => {
+    if (stepLoopActiveRef.current) return
+    stepLoopActiveRef.current = true
+    try {
+      while (stepLoopActiveRef.current) {
+        // Re-fetch simulation status — stop if no longer running.
+        const latestMeta = await fetchSimulation(simId).catch(() => null)
+        if (!latestMeta || latestMeta.status !== 'running') break
+
+        const currentStep = latestMeta.step ?? 0
+        const positions = agentPositionsRef.current
+
+        try {
+          const result = await runSimulationStep(simId, positions, currentStep, (stage) => {
+            // Update step display after execute stage completes.
+            if (stage === 'execute') pollAgents()
+          })
+          if (result.next_step !== undefined) setStep(result.next_step)
+        } catch (err: unknown) {
+          // Log and continue — transient errors (network, timeout) should not
+          // crash the loop permanently.
+          console.error('[stepLoop] stage error:', err)
+          // Brief pause before retrying to avoid hammering the API.
+          await new Promise((r) => setTimeout(r, 3000))
+        }
+      }
+    } finally {
+      stepLoopActiveRef.current = false
+    }
+  }, [simId, pollAgents])
+
+  // Start/stop the step loop based on simulation status and ownership.
+  useEffect(() => {
+    if (!isAdmin || meta?.status !== 'running') {
+      stepLoopActiveRef.current = false
+      return
+    }
+    void runStepLoop()
+    return () => {
+      stepLoopActiveRef.current = false
+    }
+  }, [isAdmin, meta?.status, runStepLoop])
 
   const statusColors: Record<string, string> = {
     pending: 'bg-gray-600',

--- a/frontend_server/frontend_server/asgi.py
+++ b/frontend_server/frontend_server/asgi.py
@@ -2,27 +2,37 @@
 ASGI config for frontend_server project.
 
 Exposes the ASGI callable as module-level variable named ``application``.
-Routes HTTP to Django and WebSocket to SimulationConsumer.
+Routes HTTP to Django and (when ENABLE_CHANNELS != 'false') WebSocket to
+SimulationConsumer.
+
+Set ENABLE_CHANNELS=false on Vercel where Channels is replaced by the SSE
+Edge Function and WebSocket support is not available.
 """
 
 import os
 
-from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
-from django.urls import path
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "frontend_server.settings")
 
-# Import consumer here (must be after Django setup)
-from translator.consumers import SimulationConsumer  # noqa: E402
+_enable_channels = os.environ.get("ENABLE_CHANNELS", "true").lower() != "false"
 
-websocket_urlpatterns = [
-    path("ws/simulations/<str:sim_id>/", SimulationConsumer.as_asgi()),
-]
+if _enable_channels:
+    from channels.routing import ProtocolTypeRouter, URLRouter
+    from django.urls import path
 
-application = ProtocolTypeRouter(
-    {
-        "http": get_asgi_application(),
-        "websocket": URLRouter(websocket_urlpatterns),
-    }
-)
+    from translator.consumers import SimulationConsumer  # noqa: E402
+
+    websocket_urlpatterns = [
+        path("ws/simulations/<str:sim_id>/", SimulationConsumer.as_asgi()),
+    ]
+
+    application = ProtocolTypeRouter(
+        {
+            "http": get_asgi_application(),
+            "websocket": URLRouter(websocket_urlpatterns),
+        }
+    )
+else:
+    # WSGI-only mode (Vercel): no WebSocket support; use SSE Edge Function instead.
+    application = get_asgi_application()

--- a/frontend_server/frontend_server/settings/base.py
+++ b/frontend_server/frontend_server/settings/base.py
@@ -32,8 +32,10 @@ if not SECRET_KEY:
 
 # Application definition
 
+_enable_channels = os.environ.get("ENABLE_CHANNELS", "true").lower() != "false"
+
 INSTALLED_APPS = [
-    "daphne",
+    *(["daphne"] if _enable_channels else []),
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -44,7 +46,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework_simplejwt",
     "rest_framework_simplejwt.token_blacklist",
-    "channels",
+    *(["channels"] if _enable_channels else []),
     "corsheaders",
     "storages",
     "allauth",
@@ -91,14 +93,18 @@ WSGI_APPLICATION = "frontend_server.wsgi.application"
 ASGI_APPLICATION = "frontend_server.asgi.application"
 
 # Django Channels — Redis channel layer
-CHANNEL_LAYERS = {
-    "default": {
-        "BACKEND": "channels_redis.core.RedisChannelLayer",
-        "CONFIG": {
-            "hosts": [("redis", 6379)],
+# Set ENABLE_CHANNELS=false to disable (e.g. on Vercel where Channels is not used).
+# REDIS_URL supports standard redis:// and TLS rediss:// URLs (Upstash format).
+if os.environ.get("ENABLE_CHANNELS", "true").lower() != "false":
+    _redis_url = os.environ.get("REDIS_URL", "redis://redis:6379")
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {
+                "hosts": [_redis_url],
+            },
         },
-    },
-}
+    }
 
 
 # Password validation

--- a/frontend_server/frontend_server/settings/production.py
+++ b/frontend_server/frontend_server/settings/production.py
@@ -39,6 +39,14 @@ if not _database_url:
     )
 DATABASES = {"default": dj_database_url.parse(_database_url)}
 
+# Vercel serverless: disable persistent DB connections (new connection per invocation).
+# Supabase PgBouncer handles pooling at the infrastructure level.
+DATABASES["default"]["CONN_MAX_AGE"] = 0
+
+# Vercel: automatically include .vercel.app hostnames so deploys work without
+# manually listing the preview URL.
+ALLOWED_HOSTS += [h for h in [".vercel.app"] if h not in ALLOWED_HOSTS]
+
 # Cookie security — enforce HTTPS in production
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True

--- a/frontend_server/frontend_server/urls.py
+++ b/frontend_server/frontend_server/urls.py
@@ -64,6 +64,18 @@ urlpatterns = [
     # REST API v1 — replay endpoints
     path("api/v1/simulations/<str:sim_id>/replay/", simulation_views.replay_meta, name="api-replay-meta"),
     path("api/v1/simulations/<str:sim_id>/replay/<int:step>/", simulation_views.replay_step, name="api-replay-step"),
+    # REST API v1 — SSE polling endpoint (used by Vercel Edge Function stream)
+    path(
+        "api/v1/simulations/<str:sim_id>/movements/latest/",
+        api_views.simulation_latest_movement,
+        name="api-simulation-latest-movement",
+    ),
+    # REST API v1 — simulation step stage endpoints (Vercel serverless microservices)
+    path("api/v1/simulations/<str:sim_id>/step/perceive/", api_views.simulation_step_perceive, name="api-step-perceive"),
+    path("api/v1/simulations/<str:sim_id>/step/retrieve/", api_views.simulation_step_retrieve, name="api-step-retrieve"),
+    path("api/v1/simulations/<str:sim_id>/step/plan/", api_views.simulation_step_plan, name="api-step-plan"),
+    path("api/v1/simulations/<str:sim_id>/step/reflect/", api_views.simulation_step_reflect, name="api-step-reflect"),
+    path("api/v1/simulations/<str:sim_id>/step/execute/", api_views.simulation_step_execute, name="api-step-execute"),
     # REST API v1 — invite endpoints
     path("api/v1/invites/", simulation_views.my_invites, name="api-invites-list"),
     path("api/v1/invites/<int:membership_id>/accept/", simulation_views.accept_invite, name="api-invite-accept"),

--- a/frontend_server/translator/api_views.py
+++ b/frontend_server/translator/api_views.py
@@ -29,6 +29,7 @@ from translator.models import (
     EnvironmentState,
     KeywordStrength,
     Map,
+    MovementRecord,
     Persona,
     PersonaScratch,
     Simulation,
@@ -519,3 +520,128 @@ def demo_step(request: Request, demo_id: str, step: int) -> Response:
             "agents": dm.agent_movements,
         }
     )
+
+
+# ---------------------------------------------------------------------------
+# SSE polling endpoint — used by the Vercel Edge Function stream
+# ---------------------------------------------------------------------------
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def simulation_latest_movement(request: Request, sim_id: str) -> Response:
+    """
+    GET /api/v1/simulations/:id/movements/latest/?after_step=N
+
+    Returns the most recent MovementRecord whose step > after_step.
+    Used by the Vercel Edge Function SSE stream to poll for new steps.
+
+    Returns 204 (no content) when no newer step exists yet.
+    """
+    try:
+        sim = Simulation.objects.get(name=sim_id)
+    except Simulation.DoesNotExist:
+        return Response({"detail": f"Simulation '{sim_id}' not found."}, status=status.HTTP_404_NOT_FOUND)
+
+    # Basic access check: must be owner or member.
+    is_owner = sim.owner == request.user
+    is_member = SimulationMembership.objects.filter(simulation=sim, user=request.user).exists()
+    if not (is_owner or is_member):
+        return Response({"detail": "Access denied."}, status=status.HTTP_403_FORBIDDEN)
+
+    after_step = int(request.query_params.get("after_step", -1))
+
+    record = (
+        MovementRecord.objects.filter(simulation=sim, step__gt=after_step).order_by("-step").first()
+    )
+    if record is None:
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    return Response(
+        {
+            "step": record.step,
+            "sim_curr_time": record.sim_curr_time.isoformat() if record.sim_curr_time else None,
+            "persona_movements": record.persona_movements,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Simulation step stage views — Vercel serverless microservices (Phase 5)
+# ---------------------------------------------------------------------------
+# Each view runs one cognitive stage for all personas. The frontend calls
+# these sequentially to drive a full simulation step.
+#
+# Execution order: perceive → retrieve → plan → reflect → execute
+# ---------------------------------------------------------------------------
+
+
+def _run_stage(request: Request, sim_id: str, stage_fn_name: str) -> Response:
+    """Shared implementation: load ReverieServer, run one stage, return result."""
+    import sys  # noqa: PLC0415
+    import os  # noqa: PLC0415
+
+    # Ensure backend_server is on sys.path so reverie imports work.
+    backend_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "backend_server")
+    if backend_dir not in sys.path:
+        sys.path.insert(0, backend_dir)
+
+    try:
+        from reverie import ReverieServer  # noqa: PLC0415
+    except ImportError as exc:
+        return Response({"detail": f"Could not import ReverieServer: {exc}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    # Verify simulation exists and requester has access.
+    try:
+        sim = Simulation.objects.get(name=sim_id)
+    except Simulation.DoesNotExist:
+        return Response({"detail": f"Simulation '{sim_id}' not found."}, status=status.HTTP_404_NOT_FOUND)
+
+    is_owner = sim.owner == request.user
+    is_member = SimulationMembership.objects.filter(simulation=sim, user=request.user).exists()
+    if not (is_owner or is_member):
+        return Response({"detail": "Access denied."}, status=status.HTTP_403_FORBIDDEN)
+
+    try:
+        stage_fn = getattr(ReverieServer, stage_fn_name)
+        result = stage_fn(sim_id)
+        return Response(result)
+    except RuntimeError as exc:
+        return Response({"detail": str(exc)}, status=status.HTTP_409_CONFLICT)
+    except Exception as exc:
+        return Response({"detail": f"Stage failed: {exc}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def simulation_step_perceive(request: Request, sim_id: str) -> Response:
+    """POST /api/v1/simulations/:id/step/perceive/ — run perceive stage."""
+    return _run_stage(request, sim_id, "run_perceive")
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def simulation_step_retrieve(request: Request, sim_id: str) -> Response:
+    """POST /api/v1/simulations/:id/step/retrieve/ — run retrieve stage."""
+    return _run_stage(request, sim_id, "run_retrieve")
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def simulation_step_plan(request: Request, sim_id: str) -> Response:
+    """POST /api/v1/simulations/:id/step/plan/ — run plan stage (LLM-intensive)."""
+    return _run_stage(request, sim_id, "run_plan")
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def simulation_step_reflect(request: Request, sim_id: str) -> Response:
+    """POST /api/v1/simulations/:id/step/reflect/ — run reflect stage."""
+    return _run_stage(request, sim_id, "run_reflect")
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def simulation_step_execute(request: Request, sim_id: str) -> Response:
+    """POST /api/v1/simulations/:id/step/execute/ — finalize step, write MovementRecord."""
+    return _run_stage(request, sim_id, "run_execute")

--- a/frontend_server/translator/migrations/0020_add_game_obj_cleanup_and_step_cache.py
+++ b/frontend_server/translator/migrations/0020_add_game_obj_cleanup_and_step_cache.py
@@ -1,0 +1,76 @@
+"""
+Migration 0020: Add game_obj_cleanup to Simulation and create SimulationStepCache.
+
+game_obj_cleanup persists the maze tile object events that need to be cleared
+at the start of the next simulation step, enabling stateless step execution on
+Vercel serverless functions.
+
+SimulationStepCache stores intermediate cognitive stage results between the
+5 separate Vercel function invocations per simulation step.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("translator", "0019_add_character_living_area"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="simulation",
+            name="game_obj_cleanup",
+            field=models.JSONField(
+                blank=True,
+                default=list,
+                help_text=(
+                    "Serialized list of [event_tuple, tile_xy] pairs tracking maze tile "
+                    "object events to clear at the start of the next simulation step."
+                ),
+            ),
+        ),
+        migrations.CreateModel(
+            name="SimulationStepCache",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "simulation",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="step_caches",
+                        to="translator.simulation",
+                    ),
+                ),
+                ("step", models.IntegerField()),
+                (
+                    "stage",
+                    models.CharField(
+                        choices=[
+                            ("perceive", "Perceive"),
+                            ("retrieve", "Retrieve"),
+                            ("plan", "Plan"),
+                            ("reflect", "Reflect"),
+                            ("execute", "Execute"),
+                        ],
+                        max_length=20,
+                    ),
+                ),
+                ("data", models.JSONField(default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "indexes": [
+                    models.Index(fields=["simulation", "step"], name="step_cache_sim_step_idx"),
+                ],
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="simulationstepcache",
+            constraint=models.UniqueConstraint(
+                fields=["simulation", "step", "stage"],
+                name="unique_simulation_step_stage",
+            ),
+        ),
+    ]

--- a/frontend_server/translator/models.py
+++ b/frontend_server/translator/models.py
@@ -52,6 +52,11 @@ class Simulation(models.Model):
     maze_name = models.CharField(max_length=255, blank=True, null=True)
     step = models.IntegerField(default=0)
     config = models.JSONField(default=dict, blank=True)
+    # Tracks maze tile object events that must be cleared at the start of the
+    # next simulation step. Serialized as a list of [event_tuple, tile_xy] pairs
+    # because JSON does not support tuple keys. Populated by run_execute() and
+    # consumed by _load_from_db() on the next step.
+    game_obj_cleanup = models.JSONField(default=list, blank=True)
     created_at = models.DateTimeField(auto_now_add=True, db_index=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -311,6 +316,42 @@ class RuntimeState(models.Model):
     key = models.CharField(max_length=255, unique=True)
     value = models.JSONField(default=dict, blank=True)
     updated_at = models.DateTimeField(auto_now=True)
+
+
+class SimulationStepCache(models.Model):
+    """Stores intermediate results between serverless simulation stage calls.
+
+    Each simulation step is split into 5 stages (perceive, retrieve, plan,
+    reflect, execute). Because each stage runs as a separate Vercel Python
+    Function invocation, intermediate outputs (perceived events, retrieved
+    memories, etc.) must be persisted between stages.
+
+    Rows are scoped to (simulation, step, stage) and overwritten on retry.
+    Old rows can be pruned once a step advances past them.
+    """
+
+    class Stage(models.TextChoices):
+        PERCEIVE = "perceive", "Perceive"
+        RETRIEVE = "retrieve", "Retrieve"
+        PLAN = "plan", "Plan"
+        REFLECT = "reflect", "Reflect"
+        EXECUTE = "execute", "Execute"
+
+    simulation = models.ForeignKey(Simulation, on_delete=models.CASCADE, related_name="step_caches")
+    step = models.IntegerField()
+    stage = models.CharField(max_length=20, choices=Stage.choices)
+    # JSON blob keyed by persona name → stage-specific output data.
+    data = models.JSONField(default=dict)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = [("simulation", "step", "stage")]
+        indexes = [
+            models.Index(fields=["simulation", "step"], name="step_cache_sim_step_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return f"StepCache({self.simulation.name}, step={self.step}, stage={self.stage})"
 
     def __str__(self) -> str:
         return f"RuntimeState({self.key})"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,33 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    },
+    {
+      "src": "frontend_server/wsgi.py",
+      "use": "@vercel/python",
+      "config": {
+        "maxLambdaSize": "50mb"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "frontend_server/wsgi.py"
+    },
+    {
+      "src": "/admin/(.*)",
+      "dest": "frontend_server/wsgi.py"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/frontend/$1"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR implements Phase 5 of the simulation architecture: stateless, serverless execution of simulation cognitive stages on Vercel. The simulation step pipeline is split into 5 independent stages (perceive → retrieve → plan → reflect → execute) that can run as separate function invocations, with intermediate results persisted to a new `SimulationStepCache` table.

## Key Changes

### Backend: Stateless Stage Methods
- Added 5 new `@classmethod` methods to `ReverieServer` for serverless execution:
  - `run_perceive()` — perceive environment, score poignancy
  - `run_retrieve()` — vector search for relevant memories
  - `run_plan()` — generate action plans (LLM-intensive)
  - `run_reflect()` — conditional reflection with new thoughts
  - `run_execute()` — finalize movement, write `MovementRecord`
- Added `_load_for_stage()` to reconstruct server state from DB without polling loop
- Added `_get_step_cache()` / `_save_step_cache()` for inter-stage result persistence
- Each stage serializes/deserializes `ConceptNode` objects as `node_id` lists for JSON storage

### Database Models
- Added `game_obj_cleanup` field to `Simulation` — tracks maze tile object events to clear at next step start
- Created `SimulationStepCache` model — stores intermediate results keyed by `(simulation, step, stage)`
- Added migration `0020_add_game_obj_cleanup_and_step_cache.py`

### Frontend API Endpoints
- Added `simulation_latest_movement()` — GET endpoint for SSE polling (returns latest `MovementRecord` after a given step)
- Added 5 stage endpoints: `simulation_step_perceive()`, `simulation_step_retrieve()`, `simulation_step_plan()`, `simulation_step_reflect()`, `simulation_step_execute()`
- Shared `_run_stage()` helper for authentication and error handling

### Vercel Edge Function (SSE Stream)
- New file: `frontend/api/simulations/[id]/stream.ts` — Edge Function that polls Django API for new `MovementRecord` rows and forwards them as Server-Sent Events
- Polls every 2 seconds, auto-reconnects with exponential backoff, 10-minute max duration per stream

### Frontend: SSE Hook & Step Orchestration
- New hook: `useSimulationSSE()` — replaces WebSocket with EventSource-based SSE connection
- Updated `SimulatePage.tsx` to:
  - Use SSE instead of WebSocket
  - Implement step orchestration loop that calls each stage API in sequence
  - Track agent positions and submit them as `EnvironmentState` before each step
  - Fallback to polling when SSE is disconnected

### Configuration & Deployment
- Added `vercel.json` — Vercel build config for Python backend + React frontend
- Updated `asgi.py` and `settings/base.py` to conditionally disable Django Channels when `ENABLE_CHANNELS=false` (Vercel mode)
- Updated `qdrant_utils.py` to support Qdrant Cloud (URL + API key) in addition to self-hosted
- Updated `.env.example` with Qdrant Cloud, Redis/Upstash, and Vercel configuration options
- Updated `settings/production.py` to disable persistent DB connections for serverless (Supabase PgBouncer pooling)

### API Client
- Added `runSimulationStep()` — orchestrates all 5 stages in sequence with optional per-stage callbacks
- Added `submitEnvironmentState()` — submits current agent positions before step execution
- Added `runStepStage()` — runs a single stage and returns result

## Implementation Details

- **Serialization**: `ConceptNode` objects are serialized as `node_id` integers in cache; reconstructed via `persona.a_mem.id_to_node` lookup in subsequent stages
- **Maze State**: `personas_tile` dict is reconstructed from `PersonaScratch.curr_tile` on each stage load; object events are restored

https://claude.ai/code/session_0121mJTVuASLXzGqxbwnTUMX