### PR TITLE
test: add map selection and simulation creation tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@types/react-router-dom": "^5.3.3",
@@ -19,20 +22,26 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.2.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^3.2.3",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^26.1.0",
     "prettier": "^3.8.1",
     "tailwindcss": "^4.2.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^3.2.3"
   }
 }

--- a/frontend/src/pages/CreateSimulationPage.test.tsx
+++ b/frontend/src/pages/CreateSimulationPage.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * Tests for CreateSimulationPage — map selection + simulation creation flow.
+ *
+ * Run: npm test  (requires: npm install)
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+import CreateSimulationPage from './CreateSimulationPage'
+import * as mapsApi from '../api/maps'
+import * as simsApi from '../api/simulations'
+
+// ── mock react-router navigate ─────────────────────────────────────────────
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+// ── mock Header (avoids unrelated render complexity) ──────────────────────
+vi.mock('../components/Header', () => ({ default: () => <header data-testid="header" /> }))
+
+// ── mock API modules ──────────────────────────────────────────────────────
+vi.mock('../api/maps')
+vi.mock('../api/simulations')
+
+// ── fixtures ──────────────────────────────────────────────────────────────
+const MAPS = [
+  {
+    id: 'the_ville',
+    name: 'The Ville',
+    description: 'A suburban town.',
+    preview_image_url: '',
+    max_agents: 25,
+  },
+  {
+    id: 'the_forest',
+    name: 'The Forest',
+    description: 'A wooded area.',
+    preview_image_url: '',
+    max_agents: 10,
+  },
+]
+
+const SIM_RESPONSE = {
+  id: 'my-sim',
+  name: 'my-sim',
+  fork_sim_code: null,
+  start_date: null,
+  curr_time: null,
+  sec_per_step: 10,
+  maze_name: 'the_ville',
+  persona_names: [],
+  step: 0,
+  map_id: 'the_ville',
+  visibility: 'private',
+  owner: 1,
+  status: 'pending',
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <CreateSimulationPage />
+    </MemoryRouter>,
+  )
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+describe('CreateSimulationPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(mapsApi.fetchMaps as Mock).mockResolvedValue({ maps: MAPS })
+    ;(simsApi.createSimulation as Mock).mockResolvedValue(SIM_RESPONSE)
+  })
+
+  describe('map loading', () => {
+    it('shows a loading indicator while maps are being fetched', () => {
+      // fetchMaps never resolves in this test
+      ;(mapsApi.fetchMaps as Mock).mockReturnValue(new Promise(() => {}))
+      renderPage()
+      expect(screen.getByText(/loading maps/i)).toBeInTheDocument()
+    })
+
+    it('renders a card for each map returned by the API', async () => {
+      renderPage()
+      await waitFor(() => expect(screen.getByText('The Ville')).toBeInTheDocument())
+      expect(screen.getByText('The Forest')).toBeInTheDocument()
+    })
+
+    it('shows map description and max_agents on each card', async () => {
+      renderPage()
+      await waitFor(() => expect(screen.getByText('A suburban town.')).toBeInTheDocument())
+      expect(screen.getByText('A wooded area.')).toBeInTheDocument()
+      expect(screen.getByText(/max agents:\s*25/i)).toBeInTheDocument()
+      expect(screen.getByText(/max agents:\s*10/i)).toBeInTheDocument()
+    })
+
+    it('pre-selects the_ville map by default', async () => {
+      renderPage()
+      // The_ville card should have the selected style (border-blue-500)
+      await waitFor(() => expect(screen.getByText('The Ville')).toBeInTheDocument())
+      const villeCard = screen.getByText('The Ville').closest('button')
+      expect(villeCard?.className).toMatch(/border-blue-500/)
+    })
+
+    it('pre-selects the first map when the_ville is not in the list', async () => {
+      const otherMaps = [MAPS[1]] // only "the_forest"
+      ;(mapsApi.fetchMaps as Mock).mockResolvedValue({ maps: otherMaps })
+      renderPage()
+      await waitFor(() => expect(screen.getByText('The Forest')).toBeInTheDocument())
+      const forestCard = screen.getByText('The Forest').closest('button')
+      expect(forestCard?.className).toMatch(/border-blue-500/)
+    })
+
+    it('still renders the form if fetchMaps rejects', async () => {
+      ;(mapsApi.fetchMaps as Mock).mockRejectedValue(new Error('Network error'))
+      renderPage()
+      await waitFor(() => expect(screen.getByRole('button', { name: /create simulation/i })).toBeInTheDocument())
+    })
+  })
+
+  describe('map selection', () => {
+    it('marks a card as selected when clicked', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await waitFor(() => expect(screen.getByText('The Forest')).toBeInTheDocument())
+
+      await user.click(screen.getByText('The Forest').closest('button')!)
+      const forestCard = screen.getByText('The Forest').closest('button')
+      expect(forestCard?.className).toMatch(/border-blue-500/)
+    })
+
+    it('deselects the previously selected card on new selection', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await waitFor(() => expect(screen.getByText('The Forest')).toBeInTheDocument())
+
+      await user.click(screen.getByText('The Forest').closest('button')!)
+      const villeCard = screen.getByText('The Ville').closest('button')
+      // The Ville should no longer have the selected border
+      expect(villeCard?.className).not.toMatch(/border-blue-500/)
+    })
+  })
+
+  describe('form submission', () => {
+    it('calls createSimulation with name, selected map, and visibility', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await waitFor(() => expect(screen.getByText('The Forest')).toBeInTheDocument())
+
+      await user.type(screen.getByPlaceholderText(/e\.g\. my_ville/i), 'my-sim')
+      await user.click(screen.getByText('The Forest').closest('button')!)
+      await user.click(screen.getByRole('button', { name: /create simulation/i }))
+
+      await waitFor(() =>
+        expect(simsApi.createSimulation).toHaveBeenCalledWith('my-sim', undefined, 'the_forest', 'private'),
+      )
+    })
+
+    it('navigates to the simulation page on success', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await waitFor(() => expect(screen.getByText('The Ville')).toBeInTheDocument())
+
+      await user.type(screen.getByPlaceholderText(/e\.g\. my_ville/i), 'my-sim')
+      await user.click(screen.getByRole('button', { name: /create simulation/i }))
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/simulate/my-sim'))
+    })
+
+    it('shows an error message when createSimulation rejects', async () => {
+      ;(simsApi.createSimulation as Mock).mockRejectedValue(new Error('name already exists'))
+      const user = userEvent.setup()
+      renderPage()
+      await waitFor(() => expect(screen.getByText('The Ville')).toBeInTheDocument())
+
+      await user.type(screen.getByPlaceholderText(/e\.g\. my_ville/i), 'taken-name')
+      await user.click(screen.getByRole('button', { name: /create simulation/i }))
+
+      await waitFor(() => expect(screen.getByText(/name already exists/i)).toBeInTheDocument())
+    })
+
+    it('disables the submit button while the request is in flight', async () => {
+      let resolve!: (v: typeof SIM_RESPONSE) => void
+      ;(simsApi.createSimulation as Mock).mockReturnValue(new Promise((r) => (resolve = r)))
+      const user = userEvent.setup()
+      renderPage()
+      await waitFor(() => expect(screen.getByText('The Ville')).toBeInTheDocument())
+
+      await user.type(screen.getByPlaceholderText(/e\.g\. my_ville/i), 'my-sim')
+      await user.click(screen.getByRole('button', { name: /create simulation/i }))
+
+      expect(screen.getByRole('button', { name: /creating/i })).toBeDisabled()
+      resolve(SIM_RESPONSE)
+    })
+
+    it('passes the selected visibility to createSimulation', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await waitFor(() => expect(screen.getByText('The Ville')).toBeInTheDocument())
+
+      await user.selectOptions(screen.getByRole('combobox'), 'public')
+      await user.type(screen.getByPlaceholderText(/e\.g\. my_ville/i), 'my-sim')
+      await user.click(screen.getByRole('button', { name: /create simulation/i }))
+
+      await waitFor(() =>
+        expect(simsApi.createSimulation).toHaveBeenCalledWith('my-sim', undefined, 'the_ville', 'public'),
+      )
+    })
+
+    it('Cancel button navigates back to dashboard', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await waitFor(() => expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument())
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }))
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard')
+    })
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,12 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    css: false,
+  },
   server: {
     port: 3000,
     // These proxies are only used when running Vite directly (no Docker/nginx).

--- a/frontend_server/translator/tests.py
+++ b/frontend_server/translator/tests.py
@@ -22,12 +22,13 @@ from django.core.management import call_command
 from django.test import TestCase
 from rest_framework_simplejwt.tokens import RefreshToken
 from translator.models import (
-    ConceptNode,
     Character,
+    ConceptNode,
     Demo,
     DemoMovement,
     EnvironmentState,
     KeywordStrength,
+    Map,
     MovementRecord,
     Persona,
     PersonaScratch,
@@ -54,6 +55,32 @@ class AuthenticatedAPITestCase(TestCase):
         )
         refresh = RefreshToken.for_user(self.user)
         self.client.defaults["HTTP_AUTHORIZATION"] = f"Bearer {refresh.access_token}"
+
+
+def _make_map(
+    map_id: str = "test_ville",
+    *,
+    name: str = "Test Ville",
+    maze_name: str = "the_ville",
+    max_agents: int = 25,
+    is_active: bool = True,
+) -> Map:
+    """Create-or-update a Map row for testing.
+
+    Uses get_or_create so tests work even when migration 0015 has already
+    seeded a row with the same primary key (e.g. 'the_ville').
+    """
+    obj, _ = Map.objects.update_or_create(
+        id=map_id,
+        defaults={
+            "name": name,
+            "description": "A cosy test town.",
+            "maze_name": maze_name,
+            "max_agents": max_agents,
+            "is_active": is_active,
+        },
+    )
+    return obj
 
 
 def _make_sim(name: str = "test-sim", **kwargs) -> Simulation:
@@ -145,6 +172,11 @@ class SimulationsListGetTests(AuthenticatedAPITestCase):
 
 
 class SimulationsListPostTests(AuthenticatedAPITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        # The create endpoint resolves map_id against the DB; seed the default.
+        self.default_map = _make_map("the_ville")
+
     def _post(self, data: dict) -> object:
         return self.client.post(
             "/api/v1/simulations/",
@@ -188,6 +220,161 @@ class SimulationsListPostTests(AuthenticatedAPITestCase):
     def test_fork_from_nonexistent_returns_404(self) -> None:
         resp = self._post({"name": "orphan", "fork_from": "ghost-sim"})
         self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# Maps list (GET /api/v1/maps/)
+# ---------------------------------------------------------------------------
+
+
+class MapsListTests(AuthenticatedAPITestCase):
+    """
+    Tests for GET /api/v1/maps/.
+
+    Note: migration 0015 seeds a 'the_ville' map into every test DB, so the
+    list is never truly empty.  Tests that need a clean slate deactivate the
+    seeded row first.
+    """
+
+    def _deactivate_seeded(self) -> None:
+        """Hide the migration-seeded maps so individual tests start clean."""
+        Map.objects.update(is_active=False)
+
+    def test_unauthenticated_returns_401(self) -> None:
+        self.client.defaults.pop("HTTP_AUTHORIZATION", None)
+        resp = self.client.get("/api/v1/maps/")
+        self.assertEqual(resp.status_code, 401)
+
+    def test_seeded_map_is_visible_by_default(self) -> None:
+        """The_ville is seeded by migration and must appear in the list."""
+        resp = self.client.get("/api/v1/maps/")
+        self.assertEqual(resp.status_code, 200)
+        ids = [m["id"] for m in resp.json()["maps"]]
+        self.assertIn("the_ville", ids)
+
+    def test_no_active_maps_returns_empty_list(self) -> None:
+        self._deactivate_seeded()
+        resp = self.client.get("/api/v1/maps/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"maps": []})
+
+    def test_lists_active_maps(self) -> None:
+        self._deactivate_seeded()
+        _make_map("test_ville", name="Test Ville")
+        _make_map("test_town", name="Test Town", maze_name="small_town")
+        resp = self.client.get("/api/v1/maps/")
+        ids = [m["id"] for m in resp.json()["maps"]]
+        self.assertIn("test_ville", ids)
+        self.assertIn("test_town", ids)
+
+    def test_inactive_maps_excluded(self) -> None:
+        self._deactivate_seeded()
+        _make_map("active_map", name="Active Map", is_active=True)
+        _make_map("hidden_map", name="Hidden Map", maze_name="hidden", is_active=False)
+        resp = self.client.get("/api/v1/maps/")
+        ids = [m["id"] for m in resp.json()["maps"]]
+        self.assertIn("active_map", ids)
+        self.assertNotIn("hidden_map", ids)
+
+    def test_maps_ordered_alphabetically_by_name(self) -> None:
+        self._deactivate_seeded()
+        _make_map("z_map", name="Zara Town", maze_name="z_map")
+        _make_map("a_map", name="Alpha City", maze_name="a_map")
+        resp = self.client.get("/api/v1/maps/")
+        names = [m["name"] for m in resp.json()["maps"]]
+        self.assertEqual(names, sorted(names))
+
+    def test_map_response_has_required_fields(self) -> None:
+        resp = self.client.get("/api/v1/maps/")
+        m = resp.json()["maps"][0]
+        for field in ("id", "name", "description", "preview_image_url", "max_agents"):
+            self.assertIn(field, m)
+
+    def test_maze_name_not_exposed_in_response(self) -> None:
+        """maze_name is an internal field and must not leak to the client."""
+        resp = self.client.get("/api/v1/maps/")
+        m = resp.json()["maps"][0]
+        self.assertNotIn("maze_name", m)
+
+
+# ---------------------------------------------------------------------------
+# Simulation creation with map selection
+# ---------------------------------------------------------------------------
+
+
+class SimulationMapSelectionTests(AuthenticatedAPITestCase):
+    """End-to-end tests for the map-selection flow in simulation creation."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # "the_ville" is already seeded by migration 0015; update_or_create is safe.
+        self.ville = _make_map("the_ville", name="The Ville", maze_name="the_ville")
+        self.forest = _make_map("test_forest", name="The Forest", maze_name="forest_maze")
+
+    def _post(self, data: dict):
+        return self.client.post(
+            "/api/v1/simulations/",
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+
+    def test_creates_simulation_with_explicit_map(self) -> None:
+        resp = self._post({"name": "forest-run", "map_id": "test_forest"})
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertEqual(data["map_id"], "test_forest")
+        self.assertEqual(data["maze_name"], "forest_maze")
+
+    def test_creates_simulation_defaults_to_the_ville(self) -> None:
+        resp = self._post({"name": "default-map-sim"})
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertEqual(data["map_id"], "the_ville")
+        self.assertEqual(data["maze_name"], "the_ville")
+
+    def test_maze_name_copied_from_map(self) -> None:
+        """maze_name on the simulation row must come from the selected map."""
+        self._post({"name": "check-maze", "map_id": "test_forest"})
+        sim = Simulation.objects.get(name="check-maze")
+        self.assertEqual(sim.maze_name, self.forest.maze_name)
+
+    def test_map_fk_stored_on_simulation(self) -> None:
+        resp = self._post({"name": "fk-check", "map_id": "test_forest"})
+        self.assertEqual(resp.status_code, 201)
+        sim = Simulation.objects.get(name="fk-check")
+        self.assertEqual(sim.map_id_id, "test_forest")
+
+    def test_invalid_map_id_returns_400(self) -> None:
+        resp = self._post({"name": "bad-map-sim", "map_id": "does_not_exist"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("error", resp.json())
+
+    def test_creator_gets_admin_membership(self) -> None:
+        self._post({"name": "member-check", "map_id": "the_ville"})
+        sim = Simulation.objects.get(name="member-check")
+        membership = SimulationMembership.objects.get(simulation=sim, user=self.user)
+        self.assertEqual(membership.role, SimulationMembership.Role.ADMIN)
+
+    def test_response_includes_map_and_maze_fields(self) -> None:
+        resp = self._post({"name": "resp-check", "map_id": "test_forest"})
+        data = resp.json()
+        self.assertIn("map_id", data)
+        self.assertIn("maze_name", data)
+
+    def test_visibility_stored_correctly(self) -> None:
+        resp = self._post({"name": "public-sim", "map_id": "the_ville", "visibility": "public"})
+        self.assertEqual(resp.status_code, 201)
+        sim = Simulation.objects.get(name="public-sim")
+        self.assertEqual(sim.visibility, "public")
+
+    @patch("qdrant_utils.copy_persona_embeddings")
+    def test_fork_inherits_map_from_request_not_source(self, _mock) -> None:
+        """When forking, the new map_id comes from the request, not the source sim."""
+        src = _make_sim("src-for-fork", map_id=self.ville)
+        _make_persona(src, "Carol")
+        resp = self._post({"name": "forked-forest", "fork_from": "src-for-fork", "map_id": "test_forest"})
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.json()["map_id"], "test_forest")
 
 
 # ---------------------------------------------------------------------------
@@ -1931,7 +2118,7 @@ class CompleteUserFlowTest(AuthenticatedAPITestCase):
 
         # --- Step 4: Drop character into simulation ---
         drop_resp = self.client.post(
-            f"/api/v1/simulations/e2e-flow-sim/drop/",
+            "/api/v1/simulations/e2e-flow-sim/drop/",
             data=json.dumps({"character_id": char_id}),
             content_type="application/json",
         )
@@ -1984,9 +2171,7 @@ class CompleteUserFlowTest(AuthenticatedAPITestCase):
         self.assertIn("Dr. Sarah Chen", agent_ids)
 
         # Verify agent detail
-        agent_detail_resp = self.client.get(
-            "/api/v1/simulations/e2e-flow-sim/agents/Dr.%20Sarah%20Chen/"
-        )
+        agent_detail_resp = self.client.get("/api/v1/simulations/e2e-flow-sim/agents/Dr.%20Sarah%20Chen/")
         self.assertEqual(agent_detail_resp.status_code, 200)
         detail = agent_detail_resp.json()
         self.assertEqual(detail["name"], "Dr. Sarah Chen")
@@ -2043,15 +2228,17 @@ class CompleteUserFlowTest(AuthenticatedAPITestCase):
         # Create first character: a doctor
         resp1 = self.client.post(
             "/api/v1/characters/",
-            data=json.dumps({
-                "name": "Doctor Marcus",
-                "age": 45,
-                "traits": "methodical, empathetic",
-                "currently": "running morning rounds",
-                "lifestyle": "structured clinical schedule",
-                "living_area": "the_ville:clinic_residence",
-                "daily_plan": "7am rounds, 10am consults, 5pm done",
-            }),
+            data=json.dumps(
+                {
+                    "name": "Doctor Marcus",
+                    "age": 45,
+                    "traits": "methodical, empathetic",
+                    "currently": "running morning rounds",
+                    "lifestyle": "structured clinical schedule",
+                    "living_area": "the_ville:clinic_residence",
+                    "daily_plan": "7am rounds, 10am consults, 5pm done",
+                }
+            ),
             content_type="application/json",
         )
         self.assertEqual(resp1.status_code, 201)
@@ -2060,15 +2247,17 @@ class CompleteUserFlowTest(AuthenticatedAPITestCase):
         # Create second character: a teacher with different schedule
         resp2 = self.client.post(
             "/api/v1/characters/",
-            data=json.dumps({
-                "name": "Teacher Amara",
-                "age": 33,
-                "traits": "patient, creative, enthusiastic",
-                "currently": "preparing lesson plans for tomorrow",
-                "lifestyle": "early to school, afternoons grading",
-                "living_area": "the_ville:maple_apartment_1a",
-                "daily_plan": "6am wake, school 8am-3pm, grading 4pm, reading 8pm",
-            }),
+            data=json.dumps(
+                {
+                    "name": "Teacher Amara",
+                    "age": 33,
+                    "traits": "patient, creative, enthusiastic",
+                    "currently": "preparing lesson plans for tomorrow",
+                    "lifestyle": "early to school, afternoons grading",
+                    "living_area": "the_ville:maple_apartment_1a",
+                    "daily_plan": "6am wake, school 8am-3pm, grading 4pm, reading 8pm",
+                }
+            ),
             content_type="application/json",
         )
         self.assertEqual(resp2.status_code, 201)


### PR DESCRIPTION
Backend (Django):
- Add _make_map() helper using update_or_create to handle the 'the_ville' row already seeded by migration 0015
- Fix SimulationsListPostTests: add setUp that seeds the default map so existing POST tests (which were silently broken) now pass
- Add MapsListTests: auth guard, active/inactive filtering, alphabetical ordering, response shape, maze_name not exposed to client
- Add SimulationMapSelectionTests: explicit map selection, default map fallback, maze_name copied from map, FK stored, invalid map → 400, admin membership created, visibility, fork with different map

Frontend (Vitest + Testing Library):
- Configure vitest in vite.config.ts (jsdom, globals, setupFiles)
- Add vitest / @testing-library/* to package.json devDependencies
- Add src/test/setup.ts (@testing-library/jest-dom matchers)
- Add CreateSimulationPage.test.tsx covering: loading state, map cards rendered, default selection, selection change, form submit with correct args, navigation on success, error display, in-flight disabled state, visibility passed through, cancel navigation

Run frontend tests after: npm install && npm test